### PR TITLE
Feat: Add post categories

### DIFF
--- a/prisma/migrations/20251022104815_add_categories/migration.sql
+++ b/prisma/migrations/20251022104815_add_categories/migration.sql
@@ -1,0 +1,32 @@
+-- AlterTable
+ALTER TABLE "posts" ADD COLUMN     "categoryId" TEXT;
+
+-- CreateTable
+CREATE TABLE "categories" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "categories_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "categories_name_key" ON "categories"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "categories_slug_key" ON "categories"("slug");
+
+-- AddForeignKey
+ALTER TABLE "posts" ADD CONSTRAINT "posts_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "categories"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Insert predefined categories
+INSERT INTO "categories" ("id", "name", "slug", "createdAt", "updatedAt") VALUES
+('cat_tech', 'Technology', 'technology', NOW(), NOW()),
+('cat_tutorial', 'Tutorial', 'tutorial', NOW(), NOW()),
+('cat_lifestyle', 'Lifestyle', 'lifestyle', NOW(), NOW()),
+('cat_review', 'Review', 'review', NOW(), NOW()),
+('cat_news', 'News', 'news', NOW(), NOW()),
+('cat_opinion', 'Opinion', 'opinion', NOW(), NOW()),
+('cat_tips', 'Tips & Tricks', 'tips-tricks', NOW(), NOW());

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,15 +20,28 @@ model User {
 }
 
 model Post {
-  id        String   @id @default(cuid())
-  title     String
-  content   String
-  slug      String   @unique
-  published Boolean  @default(false)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  authorId  String
-  author    User     @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  id         String   @id @default(cuid())
+  title      String
+  content    String
+  slug       String   @unique
+  published  Boolean  @default(false)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  authorId   String
+  categoryId String?
+  author     User     @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  category   Category? @relation(fields: [categoryId], references: [id], onDelete: SetNull)
 
   @@map("posts")
+}
+
+model Category {
+  id        String   @id @default(cuid())
+  name      String   @unique
+  slug      String   @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  posts     Post[]
+
+  @@map("categories")
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import helmet from 'helmet';
 import authRoutes from './routes/auth';
 import postRoutes from './routes/posts';
+import categoryRoutes from './routes/categories';
 import { authenticateToken } from './utils/auth';
 import { errorHandler } from './middleware/validation';
 import globalRateLimit from './middleware/rateLimit';
@@ -33,6 +34,7 @@ app.get('/health', (req, res) => {
 
 app.use('/api/auth', authRoutes);
 app.use('/api/posts', postRoutes);
+app.use('/api/categories', categoryRoutes);
 
 app.use('/api/protected', authenticateToken);
 

--- a/src/middleware/validators.ts
+++ b/src/middleware/validators.ts
@@ -1,4 +1,7 @@
 import { body } from 'express-validator';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
 
 export const validateSignup = [
   body('email')
@@ -36,4 +39,20 @@ export const validatePost = [
     .optional()
     .isBoolean()
     .withMessage('Published must be a boolean'),
+  body('categoryId')
+    .optional()
+    .custom(async (value) => {
+      if (value !== null && value !== undefined) {
+        if (typeof value !== 'string') {
+          throw new Error('Category ID must be a string');
+        }
+        const category = await prisma.category.findUnique({
+          where: { id: value },
+        });
+        if (!category) {
+          throw new Error('Category not found');
+        }
+      }
+      return true;
+    }),
 ];

--- a/src/routes/categories.ts
+++ b/src/routes/categories.ts
@@ -1,0 +1,26 @@
+import { Router, Response } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { asyncHandler } from '../middleware/validation';
+
+const router = Router();
+const prisma = new PrismaClient();
+
+// Get all categories
+router.get('/', asyncHandler(async (req: any, res: Response) => {
+  const categories = await prisma.category.findMany({
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+    },
+    orderBy: {
+      name: 'asc',
+    },
+  });
+
+  return res.json({
+    categories,
+  });
+}));
+
+export default router;

--- a/src/routes/posts.ts
+++ b/src/routes/posts.ts
@@ -23,6 +23,13 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
           username: true,
         },
       },
+      category: {
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+        },
+      },
     },
     orderBy: { createdAt: 'desc' },
     skip,
@@ -65,6 +72,13 @@ router.get('/my-posts', authenticateToken, asyncHandler(async (req: AuthRequest,
           username: true,
         },
       },
+      category: {
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+        },
+      },
     },
     orderBy: { createdAt: 'desc' },
     skip,
@@ -99,6 +113,13 @@ router.get('/:slug', asyncHandler(async (req: AuthRequest, res: Response) => {
           username: true,
         },
       },
+      category: {
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+        },
+      },
     },
   });
 
@@ -130,6 +151,13 @@ router.get('/drafts/:slug', authenticateToken, asyncHandler(async (req: AuthRequ
           username: true,
         },
       },
+      category: {
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+        },
+      },
     },
   });
 
@@ -156,7 +184,7 @@ router.post('/', validatePost, authenticateToken, handleValidationErrors, asyncH
     });
   }
 
-  const { title, content, published = false } = req.body;
+  const { title, content, published = false, categoryId } = req.body;
   const slug = generateSlug(title);
 
   // Check if slug already exists
@@ -177,12 +205,20 @@ router.post('/', validatePost, authenticateToken, handleValidationErrors, asyncH
       slug,
       published,
       authorId: req.user.id,
+      categoryId,
     },
     include: {
       author: {
         select: {
           id: true,
           username: true,
+        },
+      },
+      category: {
+        select: {
+          id: true,
+          name: true,
+          slug: true,
         },
       },
     },
@@ -203,7 +239,7 @@ router.put('/:id', validatePost, authenticateToken, handleValidationErrors, asyn
   }
 
   const { id } = req.params;
-  const { title, content, published } = req.body;
+  const { title, content, published, categoryId } = req.body;
 
   // Check if post exists and user owns it
   const existingPost = await prisma.post.findUnique({
@@ -246,12 +282,20 @@ router.put('/:id', validatePost, authenticateToken, handleValidationErrors, asyn
       content,
       slug,
       published,
+      categoryId,
     },
     include: {
       author: {
         select: {
           id: true,
           username: true,
+        },
+      },
+      category: {
+        select: {
+          id: true,
+          name: true,
+          slug: true,
         },
       },
     },

--- a/src/test/categories.test.ts
+++ b/src/test/categories.test.ts
@@ -1,0 +1,306 @@
+import { prisma } from './setup';
+import jwt from 'jsonwebtoken';
+import bcrypt from 'bcryptjs';
+
+describe('Categories API', () => {
+  const baseUrl = `http://localhost:${process.env.PORT}/api`;
+  let authToken: string;
+  let userId: string;
+  let categoryId: string;
+
+  beforeEach(async () => {
+    // Create a test user
+    const hashedPassword = await bcrypt.hash('Password123', 12);
+    const user = await prisma.user.create({
+      data: {
+        email: 'test@example.com',
+        username: 'testuser',
+        password: hashedPassword,
+      },
+    });
+    userId = user.id;
+    authToken = jwt.sign({ userId: user.id }, process.env.JWT_SECRET!);
+
+    // Get a category ID for testing
+    const categories = await prisma.category.findMany();
+    categoryId = categories[0].id;
+  });
+
+  describe('GET /api/categories', () => {
+    it('should return all categories', async () => {
+      const response = await fetch(`${baseUrl}/categories`);
+      const data: any = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toHaveProperty('categories');
+      expect(Array.isArray(data.categories)).toBe(true);
+      expect(data.categories.length).toBeGreaterThan(0);
+
+      // Check category structure
+      const category = data.categories[0];
+      expect(category).toHaveProperty('id');
+      expect(category).toHaveProperty('name');
+      expect(category).toHaveProperty('slug');
+    });
+
+    it('should not require authentication', async () => {
+      const response = await fetch(`${baseUrl}/categories`);
+      expect(response.status).toBe(200);
+    });
+
+    it('should contain exactly the predefined categories', async () => {
+      const response = await fetch(`${baseUrl}/categories`);
+      const data: any = await response.json();
+
+      expect(response.status).toBe(200);
+      
+      const expectedCategories = [
+        'Technology',
+        'Tutorial',
+        'Lifestyle',
+        'Review',
+        'News',
+        'Opinion',
+        'Tips & Tricks'
+      ];
+
+      // Extract category names from response
+      const actualCategoryNames = data.categories.map((cat: any) => cat.name).sort();
+      const expectedCategoryNames = expectedCategories.sort();
+
+      // Check that we have exactly the right number of categories
+      expect(actualCategoryNames).toHaveLength(expectedCategories.length);
+
+      // Check that all expected categories are present
+      expect(actualCategoryNames).toEqual(expectedCategoryNames);
+
+      // Verify each category has required fields
+      data.categories.forEach((category: any) => {
+        expect(category).toHaveProperty('id');
+        expect(category).toHaveProperty('name');
+        expect(category).toHaveProperty('slug');
+        expect(typeof category.id).toBe('string');
+        expect(typeof category.name).toBe('string');
+        expect(typeof category.slug).toBe('string');
+        expect(category.name.length).toBeGreaterThan(0);
+        expect(category.slug.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('POST /api/posts with category', () => {
+    it('should create a post with a category', async () => {
+      const response = await fetch(`${baseUrl}/posts`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          title: 'Test Post with Category',
+          content: 'This is a test post with a category',
+          published: true,
+          categoryId: categoryId,
+        }),
+      });
+
+      const data: any = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data).toHaveProperty('post');
+      expect(data.post).toHaveProperty('category');
+      expect(data.post.category.id).toBe(categoryId);
+      expect(data.post.category).toHaveProperty('name');
+      expect(data.post.category).toHaveProperty('slug');
+    });
+
+    it('should create a post without a category', async () => {
+      const response = await fetch(`${baseUrl}/posts`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          title: 'Test Post without Category',
+          content: 'This is a test post without a category',
+          published: false,
+        }),
+      });
+
+      const data: any = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data).toHaveProperty('post');
+      expect(data.post.category).toBeNull();
+    });
+
+    it('should reject invalid category ID', async () => {
+      const response = await fetch(`${baseUrl}/posts`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          title: 'Test Post with Invalid Category',
+          content: 'This should fail',
+          published: true,
+          categoryId: 'invalid-category-id',
+        }),
+      });
+
+      const data: any = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data).toHaveProperty('error');
+      expect(data.error).toBe('Validation failed');
+    });
+  });
+
+  describe('PUT /api/posts/:id with category', () => {
+    let postId: string;
+
+    beforeEach(async () => {
+      // Create a test post
+      const post = await prisma.post.create({
+        data: {
+          title: 'Test Post for Update',
+          content: 'This is a test post for updating',
+          slug: 'test-post-for-update',
+          published: false,
+          authorId: userId,
+        },
+      });
+      
+      postId = post.id;
+    });
+
+    it('should update a post with a category', async () => {
+      const response = await fetch(`${baseUrl}/posts/${postId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          title: 'Updated Post with Category',
+          content: 'This post has been updated with a category',
+          published: true,
+          categoryId: categoryId,
+        }),
+      });
+
+      const data: any = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toHaveProperty('post');
+      expect(data.post).toHaveProperty('category');
+      expect(data.post.category.id).toBe(categoryId);
+    });
+
+    it('should update a post to remove category', async () => {
+      // First add a category
+      await fetch(`${baseUrl}/posts/${postId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          title: 'Post with Category',
+          content: 'This post has a category',
+          published: true,
+          categoryId: categoryId,
+        }),
+      });
+
+      // Then remove the category
+      const response = await fetch(`${baseUrl}/posts/${postId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          title: 'Post without Category',
+          content: 'This post no longer has a category',
+          published: true,
+          categoryId: null,
+        }),
+      });
+
+      const data: any = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toHaveProperty('post');
+      expect(data.post.category).toBeNull();
+    });
+
+    it('should reject invalid category ID on update', async () => {
+      const response = await fetch(`${baseUrl}/posts/${postId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          title: 'Updated Post',
+          content: 'This should fail',
+          published: true,
+          categoryId: 'invalid-category-id',
+        }),
+      });
+
+      const data: any = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data).toHaveProperty('error');
+      expect(data.error).toBe('Validation failed');
+    });
+  });
+
+  describe('GET /api/posts with category info', () => {
+    let postId: string;
+
+    beforeEach(async () => {
+      // Create a test post with category
+      const post = await prisma.post.create({
+        data: {
+          title: 'Test Post for Listing',
+          content: 'This is a test post for listing',
+          slug: 'test-post-for-listing',
+          published: true,
+          authorId: userId,
+          categoryId: categoryId,
+        },
+      });
+      
+      postId = post.id;
+    });
+
+    it('should include category info in post listings', async () => {
+      const response = await fetch(`${baseUrl}/posts`);
+      const data: any = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toHaveProperty('posts');
+      expect(Array.isArray(data.posts)).toBe(true);
+
+      const postWithCategory = data.posts.find((p: any) => p.id === postId);
+      expect(postWithCategory).toBeDefined();
+      expect(postWithCategory).toHaveProperty('category');
+      expect(postWithCategory.category.id).toBe(categoryId);
+    });
+
+    it('should include category info in single post', async () => {
+      const response = await fetch(`${baseUrl}/posts/test-post-for-listing`);
+      const data: any = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toHaveProperty('post');
+      expect(data.post).toHaveProperty('category');
+      expect(data.post.category.id).toBe(categoryId);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #3

This PR adds a categories system to organize blog posts. It creates a Category model with 7 predefined categories, adds a GET /api/categories endpoint, and allows posts to be assigned to categories via an optional categoryId parameter in POST/PUT requests. All post responses now include category information.This PR adds a categories system to organize blog posts. It creates a Category model with 7 predefined categories, adds a GET /api/categories endpoint, and allows posts to be assigned to categories via an optional categoryId parameter in POST/PUT requests. All post responses now include category information.