### PR TITLE
fix: strip special characters when generating slug from title

### DIFF
--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -10,10 +10,10 @@ describe('Auth Utilities', () => {
     it('should generate a valid JWT token', () => {
       const userId = 'user-123';
       const token = generateToken(userId);
-      
+
       expect(token).toBeDefined();
       expect(typeof token).toBe('string');
-      
+
       // Verify token can be decoded
       const jwt = require('jsonwebtoken');
       const decoded = jwt.verify(token, 'test-secret');
@@ -25,7 +25,7 @@ describe('Auth Utilities', () => {
     it('should hash a password', async () => {
       const password = 'testpassword123';
       const hashed = await hashPassword(password);
-      
+
       expect(hashed).toBeDefined();
       expect(hashed).not.toBe(password);
       expect(hashed.length).toBeGreaterThan(0);
@@ -35,7 +35,7 @@ describe('Auth Utilities', () => {
       const password = 'testpassword123';
       const hash1 = await hashPassword(password);
       const hash2 = await hashPassword(password);
-      
+
       expect(hash1).not.toBe(hash2);
     });
   });
@@ -44,7 +44,7 @@ describe('Auth Utilities', () => {
     it('should return true for correct password', async () => {
       const password = 'testpassword123';
       const hashed = await hashPassword(password);
-      
+
       const isValid = await comparePassword(password, hashed);
       expect(isValid).toBe(true);
     });
@@ -53,7 +53,7 @@ describe('Auth Utilities', () => {
       const password = 'testpassword123';
       const wrongPassword = 'wrongpassword';
       const hashed = await hashPassword(password);
-      
+
       const isValid = await comparePassword(wrongPassword, hashed);
       expect(isValid).toBe(false);
     });
@@ -63,22 +63,43 @@ describe('Auth Utilities', () => {
     it('should handle multiple spaces', () => {
       const title = 'Multiple    Spaces   Here';
       const slug = generateSlug(title);
-      
+
       expect(slug).toBe('multiple-spaces-here');
     });
 
     it('should handle empty string', () => {
       const title = '';
       const slug = generateSlug(title);
-      
+
       expect(slug).toBe('');
     });
 
     it('should handle numbers and hyphens', () => {
       const title = 'Post 123 - The Best Article';
       const slug = generateSlug(title);
-      
+
       expect(slug).toBe('post-123-the-best-article');
+    });
+
+    it('should handle title ending with exclamation mark', () => {
+      const title = 'Hello world!';
+      const slug = generateSlug(title);
+
+      expect(slug).toBe('hello-world');
+    });
+
+    it('should handle special characters', () => {
+      const title = 'Hello@#\" World!$%^&*()';
+      const slug = generateSlug(title);
+
+      expect(slug).toBe('hello-world');
+    });
+
+    it('should handle commas correctly', () => {
+      const title = 'Hello, World';
+      const slug = generateSlug(title);
+
+      expect(slug).toBe('hello-world');
     });
   });
 });

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -66,5 +66,6 @@ export const generateSlug = (title: string): string => {
     .toLowerCase()
     .replace(/\s+/g, '-')
     .replace(/-+/g, '-')
+    .replace(/[^a-z0-9 -]/g, '')
     .trim();
 };


### PR DESCRIPTION
Description:

When creating or updating a post, if the title contains special characters (such as commas, exclamation marks, or symbols like @#$%^&*()), exclude those from the slug.

Fixes #7
