### PR TITLE
feat: implement posts view count feature fixes #14

### DIFF
--- a/prisma/migrations/20251027145848_add_view_count_to_posts/migration.sql
+++ b/prisma/migrations/20251027145848_add_view_count_to_posts/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "posts" ADD COLUMN     "viewCount" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ model Post {
   content         String
   slug            String    @unique
   published       Boolean   @default(false)
+  viewCount       Int       @default(0)
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
   authorId        String

--- a/src/routes/posts.ts
+++ b/src/routes/posts.ts
@@ -146,6 +146,18 @@ router.get('/:slug', cacheMiddleware(CACHE_CONFIG.TTL_POSTS_SINGLE), asyncHandle
   }
 
 
+  if (post.published) {
+    await prisma.post.update({
+      where: { id: post.id },
+      data: {
+        viewCount: {
+          increment: 1,
+        },
+      },
+    });
+    post.viewCount += 1;
+  }
+
   return res.json({ post });
 }));
 


### PR DESCRIPTION
Implement a view count tracking feature for blog posts that allows tracking how many times a post has been viewed by readers.

fixes #15