### PR TITLE
feat: Added like/unlike feature for posts

### DIFF
--- a/prisma/migrations/20251028162007_add_post_likes/migration.sql
+++ b/prisma/migrations/20251028162007_add_post_likes/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "post_likes" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "post_likes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "post_likes_userId_postId_key" ON "post_likes"("userId", "postId");
+
+-- AddForeignKey
+ALTER TABLE "post_likes" ADD CONSTRAINT "post_likes_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "post_likes" ADD CONSTRAINT "post_likes_postId_fkey" FOREIGN KEY ("postId") REFERENCES "posts"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,35 +8,37 @@ datasource db {
 }
 
 model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  username  String   @unique
+  id        String     @id @default(cuid())
+  email     String     @unique
+  username  String     @unique
   password  String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+  followers Follow[]   @relation("Follower")
+  following Follow[]   @relation("Following")
+  likes     PostLike[]
   posts     Post[]
-  followers Follow[] @relation("Follower")
-  following Follow[] @relation("Following")
 
   @@map("users")
 }
 
 model Post {
-  id              String    @id @default(cuid())
+  id              String     @id @default(cuid())
   title           String
   content         String
-  slug            String    @unique
-  published       Boolean   @default(false)
-  viewCount       Int       @default(0)
-  createdAt       DateTime  @default(now())
-  updatedAt       DateTime  @updatedAt
+  slug            String     @unique
+  published       Boolean    @default(false)
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
   authorId        String
   categoryId      String?
   metaDescription String?
   metaTitle       String?
   ogImage         String?
-  author          User      @relation(fields: [authorId], references: [id], onDelete: Cascade)
-  category        Category? @relation(fields: [categoryId], references: [id])
+  viewCount       Int        @default(0)
+  likes           PostLike[]
+  author          User       @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  category        Category?  @relation(fields: [categoryId], references: [id])
 
   @@index([title])
   @@map("posts")
@@ -58,10 +60,21 @@ model Follow {
   followerId  String
   followingId String
   createdAt   DateTime @default(now())
-  
   follower    User     @relation("Follower", fields: [followerId], references: [id], onDelete: Cascade)
   following   User     @relation("Following", fields: [followingId], references: [id], onDelete: Cascade)
 
   @@unique([followerId, followingId])
   @@map("followers")
+}
+
+model PostLike {
+  id        String   @id @default(cuid())
+  userId    String
+  postId    String
+  createdAt DateTime @default(now())
+  post      Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, postId])
+  @@map("post_likes")
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -15,6 +15,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   if (prisma) {
+    await prisma.postLike.deleteMany();
     await prisma.follow.deleteMany();
     await prisma.post.deleteMany();
     await prisma.user.deleteMany();


### PR DESCRIPTION
Added a likes feature for posts, allowing authenticated users to like or unlike posts via dedicated endpoints. The API now includes like counts in all relevant GET responses. A new PostLike model with a unique constraint ensures users can’t like the same post twice. Comprehensive tests cover liking, unliking, authentication, error handling, and like count accuracy.

Fixes #17