### PR TITLE
Feat: Added Save Posts Feature for Authenticated Users

### DIFF
--- a/prisma/migrations/20251029145533_add_saved_posts/migration.sql
+++ b/prisma/migrations/20251029145533_add_saved_posts/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "saved_posts" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "saved_posts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "saved_posts_userId_postId_key" ON "saved_posts"("userId", "postId");
+
+-- AddForeignKey
+ALTER TABLE "saved_posts" ADD CONSTRAINT "saved_posts_postId_fkey" FOREIGN KEY ("postId") REFERENCES "posts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "saved_posts" ADD CONSTRAINT "saved_posts_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,37 +8,39 @@ datasource db {
 }
 
 model User {
-  id        String     @id @default(cuid())
-  email     String     @unique
-  username  String     @unique
+  id        String      @id @default(cuid())
+  email     String      @unique
+  username  String      @unique
   password  String
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @updatedAt
-  followers Follow[]   @relation("Follower")
-  following Follow[]   @relation("Following")
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @updatedAt
+  followers Follow[]    @relation("Follower")
+  following Follow[]    @relation("Following")
   likes     PostLike[]
+  savedPosts SavedPost[]
   posts     Post[]
 
   @@map("users")
 }
 
 model Post {
-  id              String     @id @default(cuid())
+  id              String      @id @default(cuid())
   title           String
   content         String
-  slug            String     @unique
-  published       Boolean    @default(false)
-  createdAt       DateTime   @default(now())
-  updatedAt       DateTime   @updatedAt
+  slug            String      @unique
+  published       Boolean     @default(false)
+  createdAt       DateTime    @default(now())
+  updatedAt       DateTime    @updatedAt
   authorId        String
   categoryId      String?
   metaDescription String?
   metaTitle       String?
   ogImage         String?
-  viewCount       Int        @default(0)
+  viewCount       Int         @default(0)
   likes           PostLike[]
-  author          User       @relation(fields: [authorId], references: [id], onDelete: Cascade)
-  category        Category?  @relation(fields: [categoryId], references: [id])
+  savedBy         SavedPost[]
+  author          User        @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  category        Category?   @relation(fields: [categoryId], references: [id])
 
   @@index([title])
   @@map("posts")
@@ -77,4 +79,16 @@ model PostLike {
 
   @@unique([userId, postId])
   @@map("post_likes")
+}
+
+model SavedPost {
+  id        String   @id @default(cuid())
+  userId    String
+  postId    String
+  createdAt DateTime @default(now())
+  post      Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, postId])
+  @@map("saved_posts")
 }


### PR DESCRIPTION
Fixes #21

This PR implements the ability for authenticated users to save posts for later viewing. The implementation includes a new `SavedPost` model in the database schema, three new API endpoints (`GET /api/posts/saved` to retrieve paginated saved posts, `POST /api/posts/:id/save` to save a post, and `DELETE /api/posts/:id/save` to unsave a post), comprehensive error handling for authentication, duplicate saves, and full test coverage following the existing patterns used for post likes. All endpoints require authentication and properly handle cache invalidation, and the saved posts endpoint includes like counts and supports pagination.