### PR TITLE
feat: Implemented comments on posts feature

### DIFF
--- a/prisma/migrations/20251030113116_add_comments/migration.sql
+++ b/prisma/migrations/20251030113116_add_comments/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "comments" (
+    "id" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "parentId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "comments_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "comments" ADD CONSTRAINT "comments_postId_fkey" FOREIGN KEY ("postId") REFERENCES "posts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "comments" ADD CONSTRAINT "comments_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "comments" ADD CONSTRAINT "comments_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "comments"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   likes     PostLike[]
   savedPosts SavedPost[]
   posts     Post[]
+  comments  Comment[]
 
   @@map("users")
 }
@@ -40,6 +41,7 @@ model Post {
   viewCount       Int         @default(0)
   likes           PostLike[]
   savedBy         SavedPost[]
+  comments        Comment[]
   author          User        @relation(fields: [authorId], references: [id], onDelete: Cascade)
   category        Category?   @relation(fields: [categoryId], references: [id])
 
@@ -93,4 +95,20 @@ model SavedPost {
 
   @@unique([userId, postId])
   @@map("saved_posts")
+}
+
+model Comment {
+  id        String    @id @default(cuid())
+  content   String
+  postId    String
+  userId    String
+  parentId  String?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  post      Post      @relation(fields: [postId], references: [id], onDelete: Cascade)
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  parent    Comment?  @relation("CommentReplies", fields: [parentId], references: [id], onDelete: Cascade)
+  replies   Comment[] @relation("CommentReplies")
+
+  @@map("comments")
 }

--- a/src/middleware/validators.ts
+++ b/src/middleware/validators.ts
@@ -72,3 +72,9 @@ export const validatePost = [
     .isURL()
     .withMessage("OG image must be a valid URL"),
 ];
+
+export const validateComment = [
+  body("content")
+    .isLength({ min: 1, max: 5000 })
+    .withMessage("Comment content must be between 1 and 5000 characters"),
+];


### PR DESCRIPTION
This PR introduces a new comments table (with Prisma migrations) to store user comments linked to posts and authors. The backend includes endpoints to create, list, and reply on comments, with proper authorization.

fixes #25