### PR TITLE
Refactor: move tags route to controller/service tier and add popular tags sorting

### DIFF
--- a/src/controllers/tagsController.ts
+++ b/src/controllers/tagsController.ts
@@ -1,0 +1,15 @@
+import { Request, Response } from 'express';
+import { asyncHandler } from '../middleware/validation';
+import { getTags as getTagsService } from '../services/tagsService';
+
+export const getTags = asyncHandler(async (req: Request, res: Response) => {
+  const searchQuery = req.query.search as string | undefined;
+  const popular = req.query.popular === 'true';
+
+  const tags = await getTagsService(searchQuery, popular);
+
+  return res.json({
+    tags,
+  });
+});
+

--- a/src/routes/tags.ts
+++ b/src/routes/tags.ts
@@ -1,36 +1,9 @@
-import { Router, Response } from 'express';
-import { prisma } from '../lib/prisma';
-import { asyncHandler } from '../middleware/validation';
+import { Router } from 'express';
+import { getTags } from '../controllers/tagsController';
 
 const router = Router();
 
-router.get('/', asyncHandler(async (req: any, res: Response) => {
-  const searchQuery = req.query.search as string;
-
-  const whereClause: any = {};
-
-  if (searchQuery && searchQuery.trim()) {
-    whereClause.name = {
-      contains: searchQuery.trim(),
-      mode: 'insensitive',
-    };
-  }
-
-  const tags = await prisma.tag.findMany({
-    where: whereClause,
-    select: {
-      id: true,
-      name: true,
-    },
-    orderBy: {
-      name: 'asc',
-    },
-  });
-
-  return res.json({
-    tags,
-  });
-}));
+router.get('/', getTags);
 
 export default router;
 

--- a/src/services/tagsService.ts
+++ b/src/services/tagsService.ts
@@ -1,0 +1,49 @@
+import { prisma } from '../lib/prisma';
+
+export async function getTags(searchQuery?: string, popular?: boolean) {
+  const whereClause: any = {};
+
+  if (searchQuery && searchQuery.trim()) {
+    whereClause.name = {
+      contains: searchQuery.trim(),
+      mode: 'insensitive',
+    };
+  }
+
+  const tags = await prisma.tag.findMany({
+    where: whereClause,
+    select: {
+      id: true,
+      name: true,
+      _count: {
+        select: {
+          posts: true,
+        },
+      },
+    },
+  });
+
+  // Map tags to include postCount
+  const tagsWithCount = tags.map((tag) => ({
+    id: tag.id,
+    name: tag.name,
+    postCount: tag._count.posts,
+  }));
+
+  // Sort based on popular parameter
+  if (popular) {
+    // Sort by post count descending (most used first), then by name ascending for ties
+    tagsWithCount.sort((a, b) => {
+      if (b.postCount !== a.postCount) {
+        return b.postCount - a.postCount;
+      }
+      return a.name.localeCompare(b.name);
+    });
+  } else {
+    // Default: sort alphabetically by name
+    tagsWithCount.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  return tagsWithCount;
+}
+


### PR DESCRIPTION
- Refactor tags route to follow 3-tier architecture pattern (Routes -> Controllers ->’ Services)
- Create tagsService.ts with getTags() business logic
- Create tagsController.ts with HTTP request/response handling
- Update tags.ts route to use controller
- Add ?popular=true query parameter to sort tags by post count
- Include postCount in all tag responses
- Update existing tests to work with new structure
- Add 5 new tests for popular sorting feature
- All 204 tests passing (199 existing + 5 new)

Test Pacth Applied result without golden solution:
<img width="1471" height="870" alt="before" src="https://github.com/user-attachments/assets/9649b353-8c99-4d3d-a1fc-c3f5fa705403" />

Test Pacth Applied result with golden solution:
<img width="1463" height="882" alt="after" src="https://github.com/user-attachments/assets/967ef61c-9a5a-400f-bff4-c011b8e87d34" />


Breaking changes: None - fully backward compatible

Fixes: #74 