### PR TITLE
feat: add change password endpoint

### DIFF
--- a/src/middleware/validators.ts
+++ b/src/middleware/validators.ts
@@ -147,3 +147,21 @@ export const validatePagination = [
     .withMessage("Limit must be between 1 and 100")
     .toInt(),
 ];
+
+export const validatePasswordChange = [
+  body("currentPassword")
+    .notEmpty()
+    .withMessage("Current password is required"),
+  body("newPassword")
+    .isLength({ min: 8 })
+    .matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/)
+    .withMessage(
+      "Password must be at least 8 characters with uppercase, lowercase, and number"
+    )
+    .custom((value, { req }) => {
+      if (value === req.body.currentPassword) {
+        throw new Error("New password must be different from current password");
+      }
+      return true;
+    }),
+];

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,14 +1,17 @@
 import { Router } from 'express';
 import { authenticateToken } from '../utils/auth';
-import { validateSignup, validateLogin } from '../middleware/validators';
+import { validateSignup, validateLogin, validatePasswordChange } from '../middleware/validators';
 import { handleValidationErrors } from '../middleware/validation';
-import { signup, login, deactivateAccount } from '../controllers/authController';
+import { signup, login, changePassword, deactivateAccount } from '../controllers/authController';
 
 const router = Router();
 
 router.post('/signup', validateSignup, handleValidationErrors, signup);
 
 router.post('/login', validateLogin, handleValidationErrors, login);
+
+
+router.put('/password', authenticateToken, validatePasswordChange, handleValidationErrors, changePassword);
 
 router.delete('/account', authenticateToken, deactivateAccount);
 


### PR DESCRIPTION
- Add PUT /api/auth/password endpoint for authenticated users
- Require current password verification for security
- Validate new password with same rules as signup (min 8 chars, uppercase, lowercase, number)
- Prevent reusing current password as new password
- Add validatePasswordChange validator middleware
- Add changePassword controller function
- Add comprehensive test coverage (8 new tests)

Test Patch Applied Result without Golden Solution:
<img width="1465" height="843" alt="changePassword-before" src="https://github.com/user-attachments/assets/ef625c25-08c8-45e4-8dd0-b9612a284196" />

Test Patch Applied Result with Golden Solution:
<img width="1440" height="852" alt="changePassword-after" src="https://github.com/user-attachments/assets/cee20f82-c659-47bd-9712-f425d15a13b7" />


Breaking changes: None - new endpoint only
Fixes: #56 