### PR TITLE
feat: add account reactivation endpoint

### DIFF
--- a/src/middleware/validators.ts
+++ b/src/middleware/validators.ts
@@ -165,3 +165,14 @@ export const validatePasswordChange = [
       return true;
     }),
 ];
+
+export const validateReactivate = [
+  body("email")
+    .trim()
+    .isEmail()
+    .normalizeEmail()
+    .withMessage("Please provide a valid email"),
+  body("password")
+    .notEmpty()
+    .withMessage("Password is required"),
+];

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,8 +1,8 @@
 import { Router } from 'express';
 import { authenticateToken } from '../utils/auth';
-import { validateSignup, validateLogin, validatePasswordChange } from '../middleware/validators';
+import { validateSignup, validateLogin, validatePasswordChange, validateReactivate } from '../middleware/validators';
 import { handleValidationErrors } from '../middleware/validation';
-import { signup, login, changePassword, deactivateAccount } from '../controllers/authController';
+import { signup, login, changePassword, reactivateAccount, deactivateAccount } from '../controllers/authController';
 
 const router = Router();
 
@@ -10,6 +10,7 @@ router.post('/signup', validateSignup, handleValidationErrors, signup);
 
 router.post('/login', validateLogin, handleValidationErrors, login);
 
+router.post('/reactivate', validateReactivate, handleValidationErrors, reactivateAccount);
 
 router.put('/password', authenticateToken, validatePasswordChange, handleValidationErrors, changePassword);
 


### PR DESCRIPTION
- Add POST /api/auth/reactivate endpoint to reactivate deactivated accounts
- Require email and password verification for security
- Return new JWT token for immediate access after reactivation
- Add validateReactivate validator for input validation
- Add comprehensive test coverage (8 test cases)
- All tests passing 

Test patch applied result without golden solution:
<img width="1452" height="862" alt="before" src="https://github.com/user-attachments/assets/4376bc36-1de5-45f9-80d0-0b374d4a602f" />

Test patch applied result with golden solution:
<img width="1460" height="892" alt="after" src="https://github.com/user-attachments/assets/957c05da-1ae4-44cb-bce5-86a874227714" />

[Eval tool link](https://eval.turing.com/conversations/189710/view)





Fixes: #88 