### PR TITLE
feat: add edit and delete comment endpoints

### DIFF
--- a/src/controllers/commentsController.ts
+++ b/src/controllers/commentsController.ts
@@ -3,6 +3,7 @@ import { AuthRequest } from '../utils/auth';
 import { asyncHandler } from '../middleware/validation';
 import { prisma } from '../lib/prisma';
 import { invalidateCache } from '../middleware/cache';
+import { NotFoundError, ForbiddenError, UnauthorizedError } from '../utils/errors';
 
 async function getThreadDepth(commentId: string, depth: number = 0): Promise<number> {
   if (depth >= 5) {
@@ -347,5 +348,99 @@ export const unlikeComment = asyncHandler(async (req: AuthRequest, res: Response
   return res.json({
     message: 'Comment unliked successfully',
     likeCount,
+  });
+});
+
+export const updateComment = asyncHandler(async (req: AuthRequest, res: Response) => {
+  if (!req.user) {
+    throw new UnauthorizedError('Authentication required');
+  }
+
+  const { postId, commentId } = req.params;
+  const { content } = req.body;
+
+  const post = await prisma.post.findUnique({
+    where: { id: postId },
+  });
+
+  if (!post) {
+    throw new NotFoundError('Post not found');
+  }
+
+  const comment = await prisma.comment.findUnique({
+    where: { id: commentId },
+  });
+
+  if (!comment || comment.postId !== postId) {
+    throw new NotFoundError('Comment not found');
+  }
+
+  if (comment.userId !== req.user.id) {
+    throw new ForbiddenError('You can only edit your own comments');
+  }
+
+  const updatedComment = await prisma.comment.update({
+    where: { id: commentId },
+    data: { content },
+    include: {
+      user: {
+        select: {
+          id: true,
+          username: true,
+        },
+      },
+    },
+  });
+
+  const likeCount = await prisma.commentLike.count({
+    where: { commentId: commentId },
+  });
+
+  invalidateCache.invalidatePostCache(post.slug);
+
+  return res.json({
+    message: 'Comment updated successfully',
+    comment: {
+      ...updatedComment,
+      likeCount,
+    },
+  });
+});
+
+export const deleteComment = asyncHandler(async (req: AuthRequest, res: Response) => {
+  if (!req.user) {
+    throw new UnauthorizedError('Authentication required');
+  }
+
+  const { postId, commentId } = req.params;
+
+  const post = await prisma.post.findUnique({
+    where: { id: postId },
+  });
+
+  if (!post) {
+    throw new NotFoundError('Post not found');
+  }
+
+  const comment = await prisma.comment.findUnique({
+    where: { id: commentId },
+  });
+
+  if (!comment || comment.postId !== postId) {
+    throw new NotFoundError('Comment not found');
+  }
+
+  if (comment.userId !== req.user.id) {
+    throw new ForbiddenError('You can only delete your own comments');
+  }
+
+  await prisma.comment.delete({
+    where: { id: commentId },
+  });
+
+  invalidateCache.invalidatePostCache(post.slug);
+
+  return res.json({
+    message: 'Comment deleted successfully',
   });
 });

--- a/src/routes/comments.ts
+++ b/src/routes/comments.ts
@@ -8,6 +8,8 @@ import {
   replyToComment,
   likeComment,
   unlikeComment,
+  updateComment,
+  deleteComment,
 } from '../controllers/commentsController';
 
 const router = Router();
@@ -40,6 +42,20 @@ router.delete(
   '/:postId/comments/:commentId/like',
   authenticateToken,
   unlikeComment
+);
+
+router.put(
+  '/:postId/comments/:commentId',
+  authenticateToken,
+  validateComment,
+  handleValidationErrors,
+  updateComment
+);
+
+router.delete(
+  '/:postId/comments/:commentId',
+  authenticateToken,
+  deleteComment
 );
 
 export default router;


### PR DESCRIPTION
- Add PUT /api/posts/:postId/comments/:commentId endpoint to update comments
- Add DELETE /api/posts/:postId/comments/:commentId endpoint to delete comments
- Implement ownership verification (users can only edit/delete their own comments)
- Use centralized error handling (AppError classes)
- Add comprehensive test coverage (13 new test cases)
- All tests passing (22/22)
- Cache invalidation on update/delete
- Cascade delete for nested replies handled by database

Test patch applied result without golden solution:
<img width="1470" height="847" alt="before" src="https://github.com/user-attachments/assets/1633b785-ada6-4960-b036-4a191a9f083f" />

Test patch applied result with golden solution:
<img width="1466" height="852" alt="after" src="https://github.com/user-attachments/assets/5aafea48-c4bb-4403-8243-bc9dc89f5ce4" />

[Eval Tool Link](https://eval.turing.com/conversations/189712/view)

Fixes: #61 