### PR TITLE
Add refresh token support (DB-backed) + logout / revoke-all sessions

### DIFF
--- a/prisma/migrations/20251120204726_add_refresh_tokens/migration.sql
+++ b/prisma/migrations/20251120204726_add_refresh_tokens/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "refresh_tokens" (
+    "id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "refresh_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "refresh_tokens_token_key" ON "refresh_tokens"("token");
+
+-- CreateIndex
+CREATE INDEX "refresh_tokens_userId_idx" ON "refresh_tokens"("userId");
+
+-- CreateIndex
+CREATE INDEX "refresh_tokens_expiresAt_idx" ON "refresh_tokens"("expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "refresh_tokens" ADD CONSTRAINT "refresh_tokens_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,23 +8,24 @@ datasource db {
 }
 
 model User {
-  id             String        @id @default(cuid())
-  email          String        @unique
-  username       String        @unique
+  id             String         @id @default(cuid())
+  email          String         @unique
+  username       String         @unique
   password       String
   profilePicture String?
   about          String?
   deletedAt      DateTime?
-  createdAt      DateTime      @default(now())
-  updatedAt      DateTime      @updatedAt
-  followers      Follow[]      @relation("Follower")
-  following      Follow[]      @relation("Following")
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime       @updatedAt
+  followers      Follow[]       @relation("Follower")
+  following      Follow[]       @relation("Following")
   likes          PostLike[]
   commentLikes   CommentLike[]
   savedPosts     SavedPost[]
   posts          Post[]
   comments       Comment[]
   postReports    PostReport[]
+  refreshTokens  RefreshToken[]
 
   @@map("users")
 }
@@ -175,4 +176,17 @@ model PostTag {
 
   @@unique([postId, tagId])
   @@map("post_tags")
+}
+
+model RefreshToken {
+  id        String   @id @default(cuid())
+  token     String   @unique
+  userId    String
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([expiresAt])
+  @@map("refresh_tokens")
 }

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -2,13 +2,19 @@ import { Router } from 'express';
 import { authenticateToken } from '../utils/auth';
 import { validateSignup, validateLogin, validatePasswordChange, validateReactivate } from '../middleware/validators';
 import { handleValidationErrors } from '../middleware/validation';
-import { signup, login, changePassword, reactivateAccount, deactivateAccount } from '../controllers/authController';
+import { signup, login, changePassword, reactivateAccount, deactivateAccount, refreshAccessToken, logout, logoutAll } from '../controllers/authController';
 
 const router = Router();
 
 router.post('/signup', validateSignup, handleValidationErrors, signup);
 
 router.post('/login', validateLogin, handleValidationErrors, login);
+
+router.post('/refresh', refreshAccessToken);
+
+router.post('/logout', logout);
+
+router.post('/logout-all', authenticateToken, logoutAll);
 
 router.post('/reactivate', validateReactivate, handleValidationErrors, reactivateAccount);
 


### PR DESCRIPTION
## Summary

Implemented a refresh-token based authentication flow (short-lived access tokens + long-lived DB-backed refresh tokens).  
Added endpoints to refresh access tokens and to revoke refresh tokens (single and all sessions).  
Added database model, utils, controller logic, route wiring, tests, and documentation.

**Closes [#113](https://github.com/Turing-dev-community/post-stack/issues/113)** 

---

## What Changed

### Auth Flow
- **Access tokens:** short-lived (15 min)  
- **Refresh tokens:** long-lived (7 days), stored in DB, verifiable and revocable

### New/Updated Endpoints
- `POST /api/auth/refresh` — exchange refresh token for new access token  
- `POST /api/auth/logout` — revoke a single refresh token  
- `POST /api/auth/logout-all` — revoke all refresh tokens for current user (requires access token)  
- Signup/Login/Reactivate now return both `accessToken` and `refreshToken`

### Database
- New `RefreshToken` model (`token`, `userId`, `expiresAt`, `createdAt`) with indexes and cascade delete  
- Migration added (e.g., `20251120204726_add_refresh_tokens`)

### Code
- **auth.ts** — new helpers: `generateAccessToken`, `generateRefreshToken`, `verifyRefreshToken`, `revokeRefreshToken`, `revokeAllUserRefreshTokens`, `cleanupExpiredTokens`  
- **authController.ts** — handlers updated/added: `refreshAccessToken`, `logout`, `logoutAll`; signup/login/reactivate return both tokens  
- **auth.ts** — wired new routes (`/refresh`, `/logout`, `/logout-all`)  

### Tests
- Updated/added to cover refresh, logout, revoke-all, and related flows

Test patch applied result without golden solution:
<img width="971" height="314" alt="image" src="https://github.com/user-attachments/assets/a30869ff-639f-48fb-b642-22c4abcec570" />

Test patch applied result with golden solution:
<img width="882" height="363" alt="image" src="https://github.com/user-attachments/assets/f9ca5f1f-6b3b-47b9-a8c5-e52bcc8a4d3c" />

