### PR TITLE
feat: implement temporary account lockout after failed login attempts

### DIFF
--- a/prisma/migrations/20251121101654_add_account_lockout_fields/migration.sql
+++ b/prisma/migrations/20251121101654_add_account_lockout_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "failedLoginAttempts" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "lockedUntil" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,17 +8,19 @@ datasource db {
 }
 
 model User {
-  id             String         @id @default(cuid())
-  email          String         @unique
-  username       String         @unique
-  password       String
-  profilePicture String?
-  about          String?
-  deletedAt      DateTime?
-  createdAt      DateTime       @default(now())
-  updatedAt      DateTime       @updatedAt
-  followers      Follow[]       @relation("Follower")
-  following      Follow[]       @relation("Following")
+  id                   String        @id @default(cuid())
+  email                String        @unique
+  username             String        @unique
+  password             String
+  profilePicture       String?
+  about                String?
+  deletedAt            DateTime?
+  failedLoginAttempts  Int           @default(0)
+  lockedUntil          DateTime?
+  createdAt            DateTime      @default(now())
+  updatedAt            DateTime      @updatedAt
+  followers      Follow[]      @relation("Follower")
+  following      Follow[]      @relation("Following")
   likes          PostLike[]
   commentLikes   CommentLike[]
   savedPosts     SavedPost[]

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,0 +1,24 @@
+/**
+ * Authentication-related configuration constants
+ */
+
+/**
+ * Maximum number of consecutive failed login attempts before account lockout
+ * Can be overridden via MAX_FAILED_LOGIN_ATTEMPTS environment variable
+ * Default: 5 attempts
+ */
+export const MAX_FAILED_LOGIN_ATTEMPTS = parseInt(
+  process.env.MAX_FAILED_LOGIN_ATTEMPTS || '5',
+  10
+);
+
+/**
+ * Account lockout duration in milliseconds
+ * Can be overridden via ACCOUNT_LOCKOUT_DURATION_MS environment variable
+ * Default: 900000 ms (15 minutes)
+ */
+export const ACCOUNT_LOCKOUT_DURATION_MS = parseInt(
+  process.env.ACCOUNT_LOCKOUT_DURATION_MS || '900000',
+  10
+);
+

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -4,6 +4,7 @@ import { Request, Response, NextFunction } from 'express';
 import { prisma } from '../lib/prisma';
 import type { User } from '@prisma/client';
 import type { Role } from '../middleware/authorization';
+import { ACCOUNT_LOCKOUT_DURATION_MS } from '../constants/auth';
 
 export interface AuthRequest extends Request {
   user?: {
@@ -166,3 +167,27 @@ export const generateSlug = (title: string): string => {
     .replace(/[^a-z0-9 -]/g, '')
     .trim();
 };
+
+/**
+ * Check if account is currently locked
+ */
+export function isAccountLocked(lockedUntil: Date | null): boolean {
+  if (!lockedUntil) return false;
+  return new Date() < lockedUntil;
+}
+
+/**
+ * Calculate lockout expiration time
+ */
+export function calculateLockoutExpiration(): Date {
+  return new Date(Date.now() + ACCOUNT_LOCKOUT_DURATION_MS);
+}
+
+/**
+ * Get seconds until account is unlocked
+ */
+export function getSecondsUntilUnlock(lockedUntil: Date): number {
+  const now = Date.now();
+  const unlockTime = lockedUntil.getTime();
+  return Math.max(0, Math.ceil((unlockTime - now) / 1000));
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -47,6 +47,28 @@ export class UnauthorizedError extends AppError {
 }
 
 /**
+ * Account Locked Error (423)
+ * Used when an account is temporarily locked due to multiple failed login attempts
+ */
+export class AccountLockedError extends AppError {
+  public readonly lockedUntil: Date;
+  public readonly retryAfter: number;
+
+  constructor(lockedUntil: Date, message?: string) {
+    const retryAfter = Math.max(0, Math.ceil((lockedUntil.getTime() - Date.now()) / 1000));
+    super(
+      message || 'Account temporarily locked due to multiple failed login attempts',
+      423,
+      true,
+      { lockedUntil: lockedUntil.toISOString(), retryAfter }
+    );
+    this.name = 'AccountLockedError';
+    this.lockedUntil = lockedUntil;
+    this.retryAfter = retryAfter;
+  }
+}
+
+/**
  * Forbidden Error (403)
  */
 export class ForbiddenError extends AppError {


### PR DESCRIPTION
- Add failedLoginAttempts and lockedUntil fields to User model
- Create auth constants for configurable lockout settings
- Implement lockout logic in login controller
- Add AccountLockedError class for proper error handling
- Add utility functions for lockout calculations
- Add comprehensive test coverage for lockout scenarios
- Prevent information leakage with generic error messages
- Auto-unlock accounts after lockout period expires

Configuration:
- MAX_FAILED_LOGIN_ATTEMPTS (default: 5)
- ACCOUNT_LOCKOUT_DURATION_MS (default: 15 minutes)

Test patch applied without golden solution:
<img width="1332" height="842" alt="before" src="https://github.com/user-attachments/assets/5fc5cb72-fb8b-47bd-bc0d-5c39958a5fea" />



Test patch applied with golden solution:
<img width="1071" height="672" alt="after" src="https://github.com/user-attachments/assets/54b8f069-7a40-4a88-be8f-cbfe9aee9fb0" />


[Eval Tool Link](https://eval.turing.com/conversations/189723/view)
Fixes: #116 