### PR TITLE
fix: Add missing scheduledAt field to schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Post {
   allowComments   Boolean      @default(true)
   createdAt       DateTime     @default(now())
   updatedAt       DateTime     @updatedAt
+  scheduledAt     DateTime?
   authorId        String
   categoryId      String?
   metaDescription String?
@@ -58,6 +59,7 @@ model Post {
 
   @@index([title])
   @@index([featured])
+  @@index([scheduledAt])
   @@map("posts")
 }
 


### PR DESCRIPTION
## Description

- Currently `scheduledAt` field is added to db via migation file but is missing in schema.prisma file so if someone tries to generate a migration using prisma cli it generates a migration file that removes scheduledAt. 
- Our schema.prisma file should reflect the exact db state all the times.