### PR TITLE
feat: add RSS feed endpoint for published posts

### DIFF
--- a/src/controllers/sitemapController.ts
+++ b/src/controllers/sitemapController.ts
@@ -8,6 +8,10 @@ interface SitemapUrl {
   priority?: number;
 }
 
+const formatRfc822Date = (date: Date): string => {
+  return new Date(date).toUTCString();
+};
+
 const escapeXml = (unsafe: string): string => {
   return unsafe.replace(/[<>&'"]/g, (c) => {
     switch (c) {
@@ -173,5 +177,60 @@ export const getSitemap = async (req: Request, res: Response) => {
   } catch (error) {
     console.error('Error generating sitemap:', error);
     res.status(500).json({ error: 'Failed to generate sitemap' });
+  }
+};
+
+export const getRssFeed = async (req: Request, res: Response) => {
+  try {
+    const baseUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+
+    const posts = await prisma.post.findMany({
+      where: {
+        published: true,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      select: {
+        slug: true,
+        title: true,
+        content: true,
+        createdAt: true,
+      },
+      take: 50,
+    });
+
+    let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
+    xml += '<rss version="2.0">\n';
+    xml += '  <channel>\n';
+    xml += `    <title>${escapeXml('Blog RSS Feed')}</title>\n`;
+    xml += `    <link>${escapeXml(baseUrl)}</link>\n`;
+    xml += `    <description>${escapeXml('Latest published posts')}</description>\n`;
+    xml += `    <lastBuildDate>${formatRfc822Date(new Date())}</lastBuildDate>\n`;
+
+    posts.forEach((post) => {
+      const link = `${baseUrl}/posts/${post.slug}`;
+      const rawDescription = post.content || '';
+      const trimmedDescription =
+        rawDescription.length > 500 ? `${rawDescription.slice(0, 500)}...` : rawDescription;
+
+      xml += '    <item>\n';
+      xml += `      <title>${escapeXml(post.title)}</title>\n`;
+      xml += `      <link>${escapeXml(link)}</link>\n`;
+      xml += `      <guid>${escapeXml(link)}</guid>\n`;
+      xml += `      <pubDate>${formatRfc822Date(post.createdAt)}</pubDate>\n`;
+      xml += `      <description>${escapeXml(trimmedDescription)}</description>\n`;
+      xml += '    </item>\n';
+    });
+
+    xml += '  </channel>\n';
+    xml += '</rss>';
+
+    res.set('Content-Type', 'application/rss+xml; charset=utf-8');
+    res.set('Cache-Control', 'public, max-age=3600');
+    res.send(xml);
+  } catch (error) {
+    console.error('Error generating RSS feed:', error);
+    res.status(500).json({ error: 'Failed to generate RSS feed' });
   }
 };

--- a/src/routes/sitemap.ts
+++ b/src/routes/sitemap.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
-import { getSitemap } from '../controllers/sitemapController';
+import { getSitemap, getRssFeed } from '../controllers/sitemapController';
 import { asyncHandler } from '../middleware/validation';
 
 const router = Router();
 
 router.get('/sitemap.xml', asyncHandler(getSitemap));
+router.get('/feed.xml', asyncHandler(getRssFeed));
 
 export default router;


### PR DESCRIPTION
# PR Description

## Summary
Implements a public RSS 2.0 feed for published blog posts, enabling users and external feed readers to subscribe to the latest content. The feed is exposed via a dedicated XML endpoint and reuses existing post data and the configured `FRONTEND_URL` for link generation.

Fixes #117 


---

## What Changed

### **Database**
- No schema or migration changes.
- Reuses existing Post model fields:
  - `slug`
  - `title`
  - `content`
  - `published`
  - `createdAt`

### **API Endpoints**
#### `GET /feed.xml`
- Public, unauthenticated endpoint.
- Returns an RSS 2.0 feed of recently published posts.
- Uses `FRONTEND_URL` to generate absolute links and GUIDs.

---

## Features

### **RSS Feed Generation**
Creates a valid RSS 2.0 feed including:

#### **Channel Metadata**
- `title`: **Blog RSS Feed**
- `link`: derived from `FRONTEND_URL`
- `description`: **Latest published posts**
- `lastBuildDate`: current timestamp in RFC 822 format

#### **Item Entries**
For up to 50 latest published posts (sorted by `createdAt` descending):
- `<title>`: post title  
- `<link>`: `${FRONTEND_URL}/posts/:slug`  
- `<guid>`: same as link  
- `<pubDate>`: RFC 822 formatted `createdAt`  
- `<description>`: first 500 characters of content, suffixed with `...` if truncated  

### **Output & Safety**
- Uses existing `escapeXml` helper to safely encode XML special characters.
- Sets proper headers:
  - `Content-Type: application/rss+xml; charset=utf-8`
  - `Cache-Control: public, max-age=3600`

### **Error Handling**
- On Prisma failure, returns:
  ```json
  { "error": "Failed to generate RSS feed" }
  ```
- Ensures server stability by preventing unhandled exceptions.

---

## Testing

### **Added Tests**
4 new tests under `GET /feed.xml` in `src/test/sitemap.test.ts`:
1. Valid RSS structure and correct content type.
2. Published posts included as `<item>` entries with correct fields.
3. Description truncation behavior (500 characters + `...`).
4. Proper JSON 500 response when Prisma `findMany` throws an error.

### **Overall Test Suite**
- All sitemap-related tests passing.
- Total: **18 tests** (existing sitemap tests + new RSS tests).

---

## Files Modified
- **`src/controllers/sitemapController.ts`**
  - Added `formatRfc822Date` helper.
  - Implemented `getRssFeed` controller.
- **`src/routes/sitemap.ts`**
  - Added `GET /feed.xml` route using `asyncHandler(getRssFeed)`.

- **`src/test/sitemap.test.ts`**
  - Added full RSS feed test coverage.
  - 
  Eval Tool: https://eval.turing.com/conversations/192319/view

  Test patch applied result without golden solution:
<img width="1442" height="371" alt="image" src="https://github.com/user-attachments/assets/e692ff06-3267-4628-8df5-bf73ccb90860" />

Test patch applied result with golden solution:
<img width="1442" height="371" alt="image" src="https://github.com/user-attachments/assets/5e710875-c9d1-4bff-9135-5e06baaa2e31" />





