### PR TITLE
feat: add post excerpt feature

### DIFF
--- a/prisma/migrations/20251125152354_add_post_excerpt/migration.sql
+++ b/prisma/migrations/20251125152354_add_post_excerpt/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "posts" ADD COLUMN     "excerpt" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,7 @@ model Post {
   metaDescription String?
   metaTitle       String?
   ogImage         String?
+  excerpt         String?
   viewCount       Int          @default(0)
   likes           PostLike[]
   savedBy         SavedPost[]

--- a/src/controllers/posts/postsCrudController.ts
+++ b/src/controllers/posts/postsCrudController.ts
@@ -24,6 +24,7 @@ export async function createPost(
 		metaTitle,
 		metaDescription,
 		ogImage,
+		excerpt,
 		tags,
 		scheduledAt,
 	} = req.body;
@@ -39,6 +40,7 @@ export async function createPost(
 				metaTitle,
 				metaDescription,
 				ogImage,
+				excerpt,
 				tags,
 				scheduledAt,
 			},
@@ -82,6 +84,7 @@ export async function updatePost(
 		metaTitle,
 		metaDescription,
 		ogImage,
+		excerpt,
 		tags,
 	} = req.body;
 
@@ -97,6 +100,7 @@ export async function updatePost(
 				metaTitle,
 				metaDescription,
 				ogImage,
+				excerpt,
 				tags,
 			},
 			req.user.id

--- a/src/middleware/validators.ts
+++ b/src/middleware/validators.ts
@@ -86,6 +86,12 @@ export const validatePost = [
     .customSanitizer(sanitizeText)
     .isLength({ max: 160 })
     .withMessage("Meta description must be 160 characters or less"),
+  body("excerpt")
+    .optional({ nullable: true })
+    .trim()
+    .customSanitizer(sanitizeText)
+    .isLength({ max: 500 })
+    .withMessage("Excerpt must be 500 characters or less"),
   body("ogImage")
     .optional({ nullable: true })
     .trim()
@@ -159,6 +165,9 @@ export const validateBulkPosts = [
         }
         if (post.metaDescription !== undefined && post.metaDescription !== null && (typeof post.metaDescription !== "string" || post.metaDescription.trim().length > 160)) {
           throw new Error(`Post at index ${i}: metaDescription must be 160 characters or less`);
+        }
+        if (post.excerpt !== undefined && post.excerpt !== null && (typeof post.excerpt !== "string" || post.excerpt.trim().length > 500)) {
+          throw new Error(`Post at index ${i}: excerpt must be 500 characters or less`);
         }
         if (post.ogImage !== undefined && post.ogImage !== null && typeof post.ogImage !== "string") {
           throw new Error(`Post at index ${i}: ogImage must be a string or null`);

--- a/src/services/posts/types.ts
+++ b/src/services/posts/types.ts
@@ -26,6 +26,7 @@ export interface CreatePostData {
 	metaTitle?: string | null;
 	metaDescription?: string | null;
 	ogImage?: string | null;
+	excerpt?: string | null;
 	tags?: string[];
 	scheduledAt?: string | null;
 }

--- a/src/test/postsController.test.ts
+++ b/src/test/postsController.test.ts
@@ -754,5 +754,517 @@ describe('Posts Controller - Deactivated User Filtering (mocked)', () => {
       expect(response.body.post.slug).toBe('my-post');
     });
   });
+
+  describe('POST /api/posts - Post Excerpt Feature', () => {
+    it('should create a post with explicit excerpt', async () => {
+      const postData = {
+        title: 'Post with Excerpt',
+        content: '# Content',
+        excerpt: 'This is a custom excerpt for the post',
+        published: false,
+      };
+
+      (prismaMock.post.findUnique as jest.Mock).mockResolvedValue(null); // No slug collision
+      (prismaMock.post.create as jest.Mock).mockResolvedValue({
+        id: 'post-1',
+        ...postData,
+        slug: 'post-with-excerpt',
+        featured: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        authorId: activeUserId,
+        categoryId: null,
+        metaTitle: null,
+        metaDescription: null,
+        ogImage: null,
+        viewCount: 0,
+        author: { id: activeUserId, username: 'activeuser' },
+        category: null,
+        tags: [],
+      });
+      (prismaMock.postLike.count as jest.Mock).mockResolvedValue(0);
+
+      const response = await request(app)
+        .post('/api/posts')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send(postData)
+        .expect(201);
+
+      expect(response.body.post.excerpt).toBe('This is a custom excerpt for the post');
+      expect(prismaMock.post.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            excerpt: 'This is a custom excerpt for the post',
+          }),
+        })
+      );
+    });
+
+    it('should use metaDescription as excerpt when excerpt is not provided', async () => {
+      const postData = {
+        title: 'Post without Excerpt',
+        content: '# Content',
+        metaDescription: 'This is the meta description',
+        published: false,
+      };
+
+      (prismaMock.post.findUnique as jest.Mock).mockResolvedValue(null);
+      (prismaMock.post.create as jest.Mock).mockResolvedValue({
+        id: 'post-2',
+        ...postData,
+        excerpt: 'This is the meta description', // Should use metaDescription
+        slug: 'post-without-excerpt',
+        featured: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        authorId: activeUserId,
+        categoryId: null,
+        metaTitle: null,
+        ogImage: null,
+        viewCount: 0,
+        author: { id: activeUserId, username: 'activeuser' },
+        category: null,
+        tags: [],
+      });
+      (prismaMock.postLike.count as jest.Mock).mockResolvedValue(0);
+
+      const response = await request(app)
+        .post('/api/posts')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send(postData)
+        .expect(201);
+
+      expect(response.body.post.excerpt).toBe('This is the meta description');
+      expect(prismaMock.post.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            excerpt: 'This is the meta description',
+          }),
+        })
+      );
+    });
+
+    it('should set excerpt to null when neither excerpt nor metaDescription is provided', async () => {
+      const postData = {
+        title: 'Post without Excerpt or Meta',
+        content: '# Content',
+        published: false,
+      };
+
+      (prismaMock.post.findUnique as jest.Mock).mockResolvedValue(null);
+      (prismaMock.post.create as jest.Mock).mockResolvedValue({
+        id: 'post-3',
+        ...postData,
+        excerpt: null,
+        slug: 'post-without-excerpt-or-meta',
+        featured: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        authorId: activeUserId,
+        categoryId: null,
+        metaTitle: null,
+        metaDescription: null,
+        ogImage: null,
+        viewCount: 0,
+        author: { id: activeUserId, username: 'activeuser' },
+        category: null,
+        tags: [],
+      });
+      (prismaMock.postLike.count as jest.Mock).mockResolvedValue(0);
+
+      const response = await request(app)
+        .post('/api/posts')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send(postData)
+        .expect(201);
+
+      expect(response.body.post.excerpt).toBeNull();
+      expect(prismaMock.post.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            excerpt: null,
+          }),
+        })
+      );
+    });
+
+    it('should reject excerpt longer than 500 characters', async () => {
+      const longExcerpt = 'a'.repeat(501);
+      const postData = {
+        title: 'Post with Long Excerpt',
+        content: '# Content',
+        excerpt: longExcerpt,
+        published: false,
+      };
+
+      const response = await request(app)
+        .post('/api/posts')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send(postData)
+        .expect(400);
+
+      expect(response.body).toHaveProperty('error');
+      expect(response.body.error).toBe('ValidationError');
+      response.body.details.some(
+        (detail: any) => detail.msg === "Excerpt must be 500 characters or less"
+      );
+      expect(prismaMock.post.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('PUT /api/posts/:id - Post Excerpt Updates', () => {
+    it('should update post with new excerpt', async () => {
+      const postId = 'post-to-update-excerpt';
+      const existingPost = {
+        id: postId,
+        title: 'Original Title',
+        content: '# Content',
+        slug: 'original-title',
+        published: true,
+        featured: false,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        authorId: activeUserId,
+        categoryId: null,
+        excerpt: 'Old excerpt',
+        metaDescription: 'Old meta description',
+        viewCount: 0,
+      };
+
+      (prismaMock.post.findUnique as jest.Mock).mockResolvedValueOnce(existingPost);
+
+      (prismaMock.$transaction as jest.Mock).mockImplementation(async (callback: any) => {
+        return callback({
+          postTag: {
+            deleteMany: jest.fn().mockResolvedValue({}),
+          },
+          post: {
+            update: jest.fn().mockResolvedValue({
+              ...existingPost,
+              excerpt: 'New excerpt',
+              updatedAt: new Date(),
+              author: { id: activeUserId, username: 'activeuser' },
+              category: null,
+              tags: [],
+            }),
+          },
+        });
+      });
+
+      (prismaMock.postLike.count as jest.Mock).mockResolvedValue(0);
+
+      const response = await request(app)
+        .put(`/api/posts/${postId}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({
+          title: 'Original Title',
+          content: '# Content',
+          excerpt: 'New excerpt',
+        })
+        .expect(200);
+
+      expect(response.body.post.excerpt).toBe('New excerpt');
+    });
+
+    it('should clear excerpt when set to null', async () => {
+      const postId = 'post-to-clear-excerpt';
+      const existingPost = {
+        id: postId,
+        title: 'Original Title',
+        content: '# Content',
+        slug: 'original-title',
+        published: true,
+        featured: false,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        authorId: activeUserId,
+        categoryId: null,
+        excerpt: 'Existing excerpt',
+        metaDescription: 'Meta description',
+        viewCount: 0,
+      };
+
+      (prismaMock.post.findUnique as jest.Mock).mockResolvedValueOnce(existingPost);
+
+      (prismaMock.$transaction as jest.Mock).mockImplementation(async (callback: any) => {
+        return callback({
+          postTag: {
+            deleteMany: jest.fn().mockResolvedValue({}),
+          },
+          post: {
+            update: jest.fn().mockResolvedValue({
+              ...existingPost,
+              excerpt: null,
+              updatedAt: new Date(),
+              author: { id: activeUserId, username: 'activeuser' },
+              category: null,
+              tags: [],
+            }),
+          },
+        });
+      });
+
+      (prismaMock.postLike.count as jest.Mock).mockResolvedValue(0);
+
+      const response = await request(app)
+        .put(`/api/posts/${postId}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({
+          title: 'Original Title',
+          content: '# Content',
+          excerpt: null,
+        })
+        .expect(200);
+
+      expect(response.body.post.excerpt).toBeNull();
+    });
+
+    it('should update excerpt to new metaDescription when excerpt matches old metaDescription', async () => {
+      const postId = 'post-with-matching-excerpt';
+      const existingPost = {
+        id: postId,
+        title: 'Original Title',
+        content: '# Content',
+        slug: 'original-title',
+        published: true,
+        featured: false,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        authorId: activeUserId,
+        categoryId: null,
+        excerpt: 'Old meta description', // Matches old metaDescription
+        metaDescription: 'Old meta description',
+        viewCount: 0,
+      };
+
+      (prismaMock.post.findUnique as jest.Mock).mockResolvedValueOnce(existingPost);
+
+      (prismaMock.$transaction as jest.Mock).mockImplementation(async (callback: any) => {
+        return callback({
+          postTag: {
+            deleteMany: jest.fn().mockResolvedValue({}),
+          },
+          post: {
+            update: jest.fn().mockResolvedValue({
+              ...existingPost,
+              excerpt: 'New meta description', // Should update to new metaDescription
+              metaDescription: 'New meta description',
+              updatedAt: new Date(),
+              author: { id: activeUserId, username: 'activeuser' },
+              category: null,
+              tags: [],
+            }),
+          },
+        });
+      });
+
+      (prismaMock.postLike.count as jest.Mock).mockResolvedValue(0);
+
+      const response = await request(app)
+        .put(`/api/posts/${postId}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({
+          title: 'Original Title',
+          content: '# Content',
+          metaDescription: 'New meta description', // Only updating metaDescription
+        })
+        .expect(200);
+
+      expect(response.body.post.excerpt).toBe('New meta description');
+      expect(response.body.post.metaDescription).toBe('New meta description');
+    });
+
+    it('should preserve custom excerpt when metaDescription is updated', async () => {
+      const postId = 'post-with-custom-excerpt';
+      const existingPost = {
+        id: postId,
+        title: 'Original Title',
+        content: '# Content',
+        slug: 'original-title',
+        published: true,
+        featured: false,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        authorId: activeUserId,
+        categoryId: null,
+        excerpt: 'Custom excerpt text', // Custom excerpt, different from metaDescription
+        metaDescription: 'Old meta description',
+        viewCount: 0,
+      };
+
+      (prismaMock.post.findUnique as jest.Mock).mockResolvedValueOnce(existingPost);
+
+      (prismaMock.$transaction as jest.Mock).mockImplementation(async (callback: any) => {
+        return callback({
+          postTag: {
+            deleteMany: jest.fn().mockResolvedValue({}),
+          },
+          post: {
+            update: jest.fn().mockResolvedValue({
+              ...existingPost,
+              metaDescription: 'New meta description', // Only metaDescription updated
+              // excerpt should remain unchanged
+              updatedAt: new Date(),
+              author: { id: activeUserId, username: 'activeuser' },
+              category: null,
+              tags: [],
+            }),
+          },
+        });
+      });
+
+      (prismaMock.postLike.count as jest.Mock).mockResolvedValue(0);
+
+      const response = await request(app)
+        .put(`/api/posts/${postId}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({
+          title: 'Original Title',
+          content: '# Content',
+          metaDescription: 'New meta description',
+        })
+        .expect(200);
+
+      expect(response.body.post.excerpt).toBe('Custom excerpt text'); // Should preserve custom excerpt
+      expect(response.body.post.metaDescription).toBe('New meta description');
+    });
+  });
+
+  describe('POST /api/posts/bulk - Post Excerpt in Bulk Creation', () => {
+    it('should create multiple posts with excerpt support', async () => {
+      const postsData = [
+        {
+          title: 'Bulk Post 1',
+          content: '# Content 1',
+          excerpt: 'Custom excerpt for post 1',
+          published: false,
+        },
+        {
+          title: 'Bulk Post 2',
+          content: '# Content 2',
+          metaDescription: 'Meta description for post 2',
+          published: false,
+        },
+        {
+          title: 'Bulk Post 3',
+          content: '# Content 3',
+          published: false,
+        },
+      ];
+
+      const mockPosts = [
+        {
+          id: 'post-1',
+          title: 'Bulk Post 1',
+          content: '# Content 1',
+          slug: 'bulk-post-1',
+          excerpt: 'Custom excerpt for post 1',
+          metaDescription: null,
+          published: false,
+          featured: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          authorId: activeUserId,
+          categoryId: null,
+          metaTitle: null,
+          ogImage: null,
+          viewCount: 0,
+          author: { id: activeUserId, username: 'activeuser' },
+          category: null,
+          tags: [],
+        },
+        {
+          id: 'post-2',
+          title: 'Bulk Post 2',
+          content: '# Content 2',
+          slug: 'bulk-post-2',
+          excerpt: 'Meta description for post 2', // Should use metaDescription
+          metaDescription: 'Meta description for post 2',
+          published: false,
+          featured: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          authorId: activeUserId,
+          categoryId: null,
+          metaTitle: null,
+          ogImage: null,
+          viewCount: 0,
+          author: { id: activeUserId, username: 'activeuser' },
+          category: null,
+          tags: [],
+        },
+        {
+          id: 'post-3',
+          title: 'Bulk Post 3',
+          content: '# Content 3',
+          slug: 'bulk-post-3',
+          excerpt: null, // No excerpt or metaDescription
+          metaDescription: null,
+          published: false,
+          featured: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          authorId: activeUserId,
+          categoryId: null,
+          metaTitle: null,
+          ogImage: null,
+          viewCount: 0,
+          author: { id: activeUserId, username: 'activeuser' },
+          category: null,
+          tags: [],
+        },
+      ];
+
+      // Mock slug checks
+      (prismaMock.post.findMany as jest.Mock).mockResolvedValue([]); // No existing slugs
+
+      (prismaMock.$transaction as jest.Mock).mockImplementation(async (promises: any[]) => {
+        return Promise.all(
+          promises.map((_, index) => Promise.resolve(mockPosts[index]))
+        );
+      });
+
+      const response = await request(app)
+        .post('/api/posts/bulk')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ posts: postsData })
+        .expect(201);
+
+      expect(response.body.posts).toHaveLength(3);
+      expect(response.body.posts[0].excerpt).toBe('Custom excerpt for post 1');
+      expect(response.body.posts[1].excerpt).toBe('Meta description for post 2'); // Should use metaDescription
+      expect(response.body.posts[2].excerpt).toBeNull(); // No excerpt or metaDescription
+    });
+
+    it('should validate excerpt length for each post in bulk creation', async () => {
+      const longExcerpt = 'a'.repeat(501);
+      const postsData = [
+        {
+          title: 'Valid Post',
+          content: '# Content',
+          excerpt: 'Valid excerpt',
+          published: false,
+        },
+        {
+          title: 'Invalid Post',
+          content: '# Content',
+          excerpt: longExcerpt, // Too long
+          published: false,
+        },
+      ];
+
+      const response = await request(app)
+        .post('/api/posts/bulk')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ posts: postsData })
+        .expect(400);
+
+        expect(response.body).toHaveProperty('error');
+        expect(response.body.error).toBe('ValidationError');
+        response.body.details.some(
+          (detail: any) => detail.msg === "Excerpt must be 500 characters or less"
+        );      expect(prismaMock.post.create).not.toHaveBeenCalled();
+    });
+  });
 });
 


### PR DESCRIPTION
### Description
Add post excerpt functionality to the blog backend API. The excerpt field allows authors to provide a custom summary or preview text for their posts. If no excerpt is provided, the system will automatically use the metaDescription as a fallback value.

Fixes #157 

F2P tests:

<img width="1586" height="364" alt="image" src="https://github.com/user-attachments/assets/cab3e3e8-44b9-4a85-87d0-bd0410d6e2c2" />

P2P test:

<img width="646" height="138" alt="image" src="https://github.com/user-attachments/assets/fe882535-f6c9-4692-b9cd-b038383aa98c" />

[Eval tool](https://eval.turing.com/conversations/192320/view)

