### PR TITLE
fix(auth): Use environment variables for JWT token expiration instead of hardcoded values

### DIFF
--- a/env.development
+++ b/env.development
@@ -2,6 +2,8 @@
 DATABASE_URL="postgresql://blog_user:blog_password@localhost:5432/blog_dev?schema=public"
 JWT_SECRET="dev-super-secret-jwt-key-change-this-in-production"
 JWT_EXPIRES_IN="7d"
+ACCESS_TOKEN_EXPIRES_IN="15m"
+REFRESH_TOKEN_EXPIRES_IN="7d"
 PORT=3000
 NODE_ENV="development"
 FRONTEND_URL="http://localhost:4000"

--- a/env.example
+++ b/env.example
@@ -1,6 +1,8 @@
 DATABASE_URL="postgresql://username:password@localhost:5432/blog_db?schema=public"
 JWT_SECRET="your-super-secret-jwt-key-change-this-in-production"
 JWT_EXPIRES_IN="7d"
+ACCESS_TOKEN_EXPIRES_IN="15m"
+REFRESH_TOKEN_EXPIRES_IN="7d"
 PORT=3000
 NODE_ENV="development"
 FRONTEND_URL="http://localhost:4000"

--- a/env.test
+++ b/env.test
@@ -1,6 +1,8 @@
 DATABASE_URL="postgresql://blog_user:blog_password@localhost:5433/blog_test?schema=public"
 JWT_SECRET="test-super-secret-jwt-key-for-testing-only"
 JWT_EXPIRES_IN="1d"
+ACCESS_TOKEN_EXPIRES_IN="15m"
+REFRESH_TOKEN_EXPIRES_IN="1d"
 PORT=3001
 NODE_ENV="test"
 FRONTEND_URL="http://localhost:4000"

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -22,3 +22,43 @@ export const ACCOUNT_LOCKOUT_DURATION_MS = parseInt(
   10
 );
 
+export const getJWTExpiresIn = (): string => {
+  return process.env.JWT_EXPIRES_IN || '7d';
+};
+
+export const getAccessTokenExpiresIn = (): string => {
+  return process.env.ACCESS_TOKEN_EXPIRES_IN || '15m';
+};
+
+export const getRefreshTokenExpiresIn = (): string => {
+  return process.env.REFRESH_TOKEN_EXPIRES_IN || '7d';
+};
+
+export const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '7d';
+export const ACCESS_TOKEN_EXPIRES_IN = process.env.ACCESS_TOKEN_EXPIRES_IN || '15m';
+export const REFRESH_TOKEN_EXPIRES_IN = process.env.REFRESH_TOKEN_EXPIRES_IN || '7d';
+
+
+export const parseJWTExpiration = (expiresIn: string): number => {
+  const match = expiresIn.match(/^(\d+)([smhd]?)$/);
+  if (!match) {
+    throw new Error(`Invalid JWT expiration format: ${expiresIn}`);
+  }
+
+  const value = parseInt(match[1], 10);
+  const unit = match[2] || 's';
+
+  switch (unit) {
+    case 's':
+      return value * 1000;
+    case 'm':
+      return value * 60 * 1000;
+    case 'h':
+      return value * 60 * 60 * 1000;
+    case 'd':
+      return value * 24 * 60 * 60 * 1000;
+    default:
+      throw new Error(`Unknown time unit: ${unit}`);
+  }
+};
+

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,10 +1,23 @@
-import { generateToken, hashPassword, comparePassword } from '../utils/auth';
+import { setupPrismaMock } from './utils/mockPrisma';
+import { generateToken, hashPassword, comparePassword, generateAccessToken, generateRefreshToken, verifyRefreshToken } from '../utils/auth';
 import { generateSlug } from '../utils/slugUtils';
+import { parseJWTExpiration } from '../constants/auth';
+import jwt, { JwtPayload } from 'jsonwebtoken';
+import { prisma } from '../lib/prisma';
+import app from '../index';
+
+const { prisma: prismaMock } = setupPrismaMock(prisma, app);
 
 describe('Auth Utilities', () => {
   beforeEach(() => {
     process.env.JWT_SECRET = 'test-secret';
     process.env.JWT_EXPIRES_IN = '1d';
+    process.env.ACCESS_TOKEN_EXPIRES_IN = '15m';
+    process.env.REFRESH_TOKEN_EXPIRES_IN = '1d';
+  });
+
+  it('should have mocking properly configured', () => {
+    expect((prismaMock as any).isMocked).toBe(true);
   });
 
   describe('generateToken', () => {
@@ -19,6 +32,215 @@ describe('Auth Utilities', () => {
       const jwt = require('jsonwebtoken');
       const decoded = jwt.verify(token, 'test-secret');
       expect(decoded.userId).toBe(userId);
+    });
+
+    it('should use default JWT_EXPIRES_IN value', () => {
+      const userId = 'user-456';
+      
+      const token = generateToken(userId);
+      const decoded = jwt.verify(token, process.env.JWT_SECRET!) as JwtPayload;
+      
+      expect(decoded.exp).toBeDefined();
+      
+      const now = Math.floor(Date.now() / 1000);
+      const oneDayInSeconds = 24 * 60 * 60;
+      const expectedExp = now + oneDayInSeconds;
+      
+      expect(decoded.exp).toBeGreaterThan(now);
+      expect(decoded.exp).toBeLessThanOrEqual(expectedExp + 5);
+    });
+
+    it('should generate tokens with expiration', () => {
+      const userId = 'user-789';
+      
+      const token = generateToken(userId);
+      const decoded = jwt.verify(token, process.env.JWT_SECRET!) as JwtPayload;
+      
+      expect(decoded.exp).toBeDefined();
+      const now = Math.floor(Date.now() / 1000);
+      expect(decoded.exp).toBeGreaterThan(now);
+    });
+  });
+
+  describe('generateAccessToken', () => {
+    it('should generate a valid access token with default expiration', () => {
+      const userId = 'user-access-123';
+      delete process.env.ACCESS_TOKEN_EXPIRES_IN; 
+      
+      const token = generateAccessToken(userId);
+      const decoded = jwt.verify(token, process.env.JWT_SECRET!) as JwtPayload;
+      
+      expect(decoded.userId).toBe(userId);
+      expect(decoded.exp).toBeDefined();
+      
+      const now = Math.floor(Date.now() / 1000);
+      const fifteenMinutesInSeconds = 15 * 60;
+      const expectedExp = now + fifteenMinutesInSeconds;
+      
+      expect(decoded.exp).toBeGreaterThan(now);
+      expect(decoded.exp).toBeLessThanOrEqual(expectedExp + 5);
+    });
+
+    it('should use ACCESS_TOKEN_EXPIRES_IN environment variable', () => {
+      const userId = 'user-access-456';
+      process.env.ACCESS_TOKEN_EXPIRES_IN = '30m';
+      
+      const token = generateAccessToken(userId);
+      const decoded = jwt.verify(token, process.env.JWT_SECRET!) as JwtPayload;
+      
+      const now = Math.floor(Date.now() / 1000);
+      const thirtyMinutesInSeconds = 30 * 60;
+      const expectedExp = now + thirtyMinutesInSeconds;
+      
+      expect(decoded.exp).toBeGreaterThan(now);
+      expect(decoded.exp).toBeLessThanOrEqual(expectedExp + 5);
+    });
+  });
+
+  describe('generateRefreshToken', () => {
+    const testUserId = 'test-user-123';
+
+    it('should generate a refresh token with default expiration', async () => {
+      const mockRefreshToken = {
+        id: 'token-1',
+        token: expect.any(String),
+        userId: testUserId,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        createdAt: new Date(),
+      };
+
+      (prismaMock.refreshToken.create as jest.Mock).mockResolvedValue(mockRefreshToken);
+
+      const token = await generateRefreshToken(testUserId);
+      const decoded = jwt.verify(token, process.env.JWT_REFRESH_SECRET || process.env.JWT_SECRET!) as JwtPayload;
+      
+      expect(decoded.userId).toBe(testUserId);
+      expect(prismaMock.refreshToken.create).toHaveBeenCalledWith({
+        data: {
+          token: expect.any(String),
+          userId: testUserId,
+          expiresAt: expect.any(Date),
+        },
+      });
+
+      const createCall = (prismaMock.refreshToken.create as jest.Mock).mock.calls[0][0];
+      const expiresAt = createCall.data.expiresAt as Date;
+      const now = Date.now();
+      const oneDayInMs = 24 * 60 * 60 * 1000;
+      const actualDiff = expiresAt.getTime() - now;
+      
+      expect(actualDiff).toBeGreaterThanOrEqual(oneDayInMs - 5000);
+      expect(actualDiff).toBeLessThanOrEqual(oneDayInMs + 5000);
+    });
+
+    it('should store refresh token in database with correct expiration', async () => {
+      const mockRefreshToken = {
+        id: 'token-2',
+        token: expect.any(String),
+        userId: testUserId,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        createdAt: new Date(),
+      };
+
+      (prismaMock.refreshToken.create as jest.Mock).mockResolvedValue(mockRefreshToken);
+
+      await generateRefreshToken(testUserId);
+      
+      expect(prismaMock.refreshToken.create).toHaveBeenCalledTimes(1);
+      expect(prismaMock.refreshToken.create).toHaveBeenCalledWith({
+        data: {
+          token: expect.any(String),
+          userId: testUserId,
+          expiresAt: expect.any(Date),
+        },
+      });
+    });
+
+    it('should correctly calculate expiration for different time formats', async () => {
+      const mockRefreshToken = {
+        id: 'token-3',
+        token: expect.any(String),
+        userId: testUserId,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        createdAt: new Date(),
+      };
+
+      (prismaMock.refreshToken.create as jest.Mock).mockResolvedValue(mockRefreshToken);
+
+      await generateRefreshToken(testUserId);
+      
+      const createCall = (prismaMock.refreshToken.create as jest.Mock).mock.calls[0][0];
+      const expiresAt = createCall.data.expiresAt as Date;
+      const now = Date.now();
+      const actualDiff = expiresAt.getTime() - now;
+      
+      const expectedMs = 24 * 60 * 60 * 1000;
+      
+      expect(actualDiff).toBeGreaterThanOrEqual(expectedMs - 5000);
+      expect(actualDiff).toBeLessThanOrEqual(expectedMs + 5000);
+    });
+
+    it('should handle different expiration formats correctly', async () => {
+      const testCases = [
+        { env: '2h', expectedMs: 2 * 60 * 60 * 1000 },
+        { env: '30m', expectedMs: 30 * 60 * 1000 },
+        { env: '3d', expectedMs: 3 * 24 * 60 * 60 * 1000 },
+      ];
+
+      for (const testCase of testCases) {
+        process.env.REFRESH_TOKEN_EXPIRES_IN = testCase.env;
+
+        const mockToken = {
+          id: `token-${testCase.env}`,
+          token: expect.any(String),
+          userId: testUserId,
+          expiresAt: new Date(Date.now() + testCase.expectedMs),
+          createdAt: new Date(),
+        };
+
+        (prismaMock.refreshToken.create as jest.Mock).mockResolvedValue(mockToken);
+
+        await generateRefreshToken(testUserId);
+
+        const createCall = (prismaMock.refreshToken.create as jest.Mock).mock.calls[0][0];
+        const expiresAt = createCall.data.expiresAt as Date;
+        const now = Date.now();
+        const actualDiff = expiresAt.getTime() - now;
+
+        expect(actualDiff).toBeGreaterThanOrEqual(testCase.expectedMs - 5000);
+        expect(actualDiff).toBeLessThanOrEqual(testCase.expectedMs + 5000);
+
+        (prismaMock.refreshToken.create as jest.Mock).mockClear();
+      }
+
+      process.env.REFRESH_TOKEN_EXPIRES_IN = '1d';
+    });
+  });
+
+  describe('parseJWTExpiration', () => {
+    it('should parse seconds correctly', () => {
+      expect(parseJWTExpiration('60')).toBe(60 * 1000);
+      expect(parseJWTExpiration('120s')).toBe(120 * 1000);
+    });
+
+    it('should parse minutes correctly', () => {
+      expect(parseJWTExpiration('15m')).toBe(15 * 60 * 1000);
+      expect(parseJWTExpiration('30m')).toBe(30 * 60 * 1000);
+    });
+
+    it('should parse hours correctly', () => {
+      expect(parseJWTExpiration('1h')).toBe(60 * 60 * 1000);
+      expect(parseJWTExpiration('24h')).toBe(24 * 60 * 60 * 1000);
+    });
+
+    it('should parse days correctly', () => {
+      expect(parseJWTExpiration('1d')).toBe(24 * 60 * 60 * 1000);
+      expect(parseJWTExpiration('7d')).toBe(7 * 24 * 60 * 60 * 1000);
+    });
+
+    it('should throw error for invalid format', () => {
+      expect(() => parseJWTExpiration('invalid')).toThrow('Invalid JWT expiration format');
+      expect(() => parseJWTExpiration('12x')).toThrow('Invalid JWT expiration format');
     });
   });
 


### PR DESCRIPTION
## PR Summary
Fixed JWT token expiration configuration to correctly respect environment variables instead of relying on hardcoded values.

Closes https://github.com/Turing-dev-community/post-stack/issues/58

---

## What Changed

### **Problem**
- JWT token expiration times were hardcoded (`'7d'`, `'15m'`).
- Environment variables (`JWT_EXPIRES_IN`, `ACCESS_TOKEN_EXPIRES_IN`, `REFRESH_TOKEN_EXPIRES_IN`) were defined but not used.
- Token lifetimes could not be customized per environment (development, staging, production).
- Constants were loaded during module initialization, preventing runtime configuration updates.

---

Before gold patch: 
<img width="873" height="281" alt="image" src="https://github.com/user-attachments/assets/bb2bde2b-18f6-4832-a0ed-49fff51cfa2e" />

After gold patch:
<img width="860" height="309" alt="image" src="https://github.com/user-attachments/assets/f35d9a10-c8b5-481e-b7db-cbbcd28fa34b" />
