### PR TITLE
implement delete user endpoint.

### DIFF
--- a/src/controllers/usersController.ts
+++ b/src/controllers/usersController.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express';
 import { AuthRequest } from '../utils/auth';
 import { asyncHandler } from '../middleware/validation';
-import { followUser as followUserService, unfollowUser as unfollowUserService, getFollowers as getFollowersService, getFollowing as getFollowingService, getUserPublicProfile as getUserPublicProfileService, getUserActivity as getUserActivityService} from '../services/usersService';
+import { followUser as followUserService, unfollowUser as unfollowUserService, getFollowers as getFollowersService, getFollowing as getFollowingService, getUserPublicProfile as getUserPublicProfileService, getUserActivity as getUserActivityService, deleteUser as deleteUserService} from '../services/usersService';
 import { checkAuth } from '../utils/authDecorator';
 
 export const followUser = asyncHandler(async (req: AuthRequest, res: Response) => {
@@ -138,6 +138,42 @@ export const getUserPublicProfile = asyncHandler(async (req: AuthRequest, res: R
         message: 'This user account does not exist or has been deactivated.',
       });
     }
+    throw error;
+  }
+});
+
+export const deleteUser = asyncHandler(async (req: AuthRequest, res: Response) => {
+  const { userId } = req.body;
+
+  if (!userId) {
+    return res.status(400).json({
+      error: 'User ID is required',
+      message: 'Please provide a userId in the request body',
+    });
+  }
+
+  try {
+    await deleteUserService(userId);
+
+    return res.json({
+      message: 'User deleted successfully',
+    });
+  } catch (error: any) {
+    if (error.message === 'User not found') {
+      return res.status(404).json({
+        error: 'User not found',
+        message: 'This user account does not exist.',
+      });
+    }
+
+    if (error.message === 'User already deleted') {
+      return res.status(400).json({
+        error: 'User already deleted',
+        message: 'This user account has already been deleted.',
+      });
+    }
+
+    // Unknown error
     throw error;
   }
 });

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { authenticateToken } from '../utils/auth';
-import { followUser, unfollowUser, getFollowers, getFollowing, getUserActivity, getUserPublicProfile } from '../controllers/usersController';
+import { followUser, unfollowUser, getFollowers, getFollowing, getUserActivity, getUserPublicProfile, deleteUser } from '../controllers/usersController';
 import { validatePagination } from '../middleware/validators';
 import { handleValidationErrors } from '../middleware/validation';
 import { cacheMiddleware } from '../middleware/cache';
@@ -47,6 +47,11 @@ router.get(
   handleValidationErrors,
   cacheMiddleware(CACHE_CONFIG.TTL_USER_ACTIVITY),
   getUserActivity
+);
+
+router.delete(
+  '/',
+  deleteUser
 );
 
 export default router;

--- a/src/services/usersService.ts
+++ b/src/services/usersService.ts
@@ -446,3 +446,26 @@ export async function getUserPublicProfile(userId: string) {
     followingCount,
   };
 }
+
+export async function deleteUser(userId: string): Promise<void> {
+  // Check if user exists
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, deletedAt: true },
+  });
+
+  if (!user) {
+    throw new Error('User not found');
+  }
+
+  // Check if user is already deleted
+  if (user.deletedAt) {
+    throw new Error('User already deleted');
+  }
+
+  // Soft delete the user by setting deletedAt
+  await prisma.user.update({
+    where: { id: userId },
+    data: { deletedAt: new Date() },
+  });
+}


### PR DESCRIPTION
## Description

Implemented a new endpoint to delete a user by their ID. The user ID is provided in the request payload (body) rather than as a URL parameter. The deletion is performed as a soft delete, setting the deletedAt timestamp on the user record.

Fixes #176 