### PR TITLE
 Add Request Timeout Middleware

### DIFF
--- a/env.example
+++ b/env.example
@@ -5,3 +5,4 @@ PORT=3000
 NODE_ENV="development"
 FRONTEND_URL="http://localhost:4000"
 REDIS_URL="redis://localhost:6379"
+REQUEST_TIMEOUT_MS=30000

--- a/src/constants/timeout.ts
+++ b/src/constants/timeout.ts
@@ -1,0 +1,1 @@
+export const REQUEST_TIMEOUT_MS = parseInt(process.env.REQUEST_TIMEOUT_MS || '30000', 10); 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import sitemapRoutes from './routes/sitemap';
 import { authenticateToken } from './utils/auth';
 import { errorHandler } from './middleware/validation';
 import globalRateLimit from './middleware/rateLimit';
+import requestTimeout from './middleware/timeout';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -29,6 +30,9 @@ app.use(cors({
 
 // Rate Limiting
 app.use(globalRateLimit);
+
+// Request Timeout
+app.use(requestTimeout);
 
 // Body Parsing
 app.use(express.json({ limit: '10mb' }));

--- a/src/middleware/timeout.ts
+++ b/src/middleware/timeout.ts
@@ -1,0 +1,25 @@
+import { Request, Response, NextFunction } from 'express';
+import { REQUEST_TIMEOUT_MS } from '../constants/timeout';
+
+const requestTimeout = (req: Request, res: Response, next: NextFunction) => {
+  const timer = setTimeout(() => {
+    if (!res.headersSent) {
+      res.status(408).json({
+        error: 'Request Timeout',
+        message: 'The request took too long to process. Please try again.',
+      });
+    }
+  }, REQUEST_TIMEOUT_MS);
+
+  res.on('finish', () => {
+    clearTimeout(timer);
+  });
+
+  res.on('close', () => {
+    clearTimeout(timer);
+  });
+
+  next();
+};
+
+export default requestTimeout;

--- a/src/test/timeout.test.ts
+++ b/src/test/timeout.test.ts
@@ -1,0 +1,114 @@
+import request from 'supertest';
+import express, { Request, Response } from 'express';
+import requestTimeout from '../middleware/timeout';
+
+describe('Request Timeout Middleware', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    app.use(requestTimeout);
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('should allow requests that complete within timeout', async () => {
+    app.get('/fast', (req: Request, res: Response) => {
+      res.json({ message: 'Success' });
+    });
+
+    const response = await request(app).get('/fast');
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe('Success');
+  });
+
+  it('should timeout requests that exceed the configured duration', async () => {
+    const originalTimeout = process.env.REQUEST_TIMEOUT_MS;
+    process.env.REQUEST_TIMEOUT_MS = '100';
+
+    jest.resetModules();
+    const { default: shortTimeoutMiddleware } = require('../middleware/timeout');
+
+    const testApp = express();
+    testApp.use(shortTimeoutMiddleware);
+
+    testApp.get('/slow', async (req: Request, res: Response) => {
+      await new Promise(resolve => setTimeout(resolve, 200));
+      if (!res.headersSent) {
+        res.json({ message: 'This should not be sent' });
+      }
+    });
+
+    const response = await request(testApp).get('/slow');
+    expect(response.status).toBe(408);
+    expect(response.body.error).toBe('Request Timeout');
+    expect(response.body.message).toContain('took too long');
+
+    if (originalTimeout) {
+      process.env.REQUEST_TIMEOUT_MS = originalTimeout;
+    } else {
+      delete process.env.REQUEST_TIMEOUT_MS;
+    }
+    
+    jest.resetModules();
+  }, 10000);
+
+  it('should not send timeout response if headers already sent', async () => {
+    const originalTimeout = process.env.REQUEST_TIMEOUT_MS;
+    process.env.REQUEST_TIMEOUT_MS = '50';
+
+    jest.resetModules();
+    const { default: shortTimeoutMiddleware } = require('../middleware/timeout');
+
+    const testApp = express();
+    testApp.use(shortTimeoutMiddleware);
+
+    testApp.get('/partial', async (req: Request, res: Response) => {
+      res.status(200).json({ message: 'Success' });
+    });
+
+    const response = await request(testApp).get('/partial');
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe('Success');
+
+    if (originalTimeout) {
+      process.env.REQUEST_TIMEOUT_MS = originalTimeout;
+    } else {
+      delete process.env.REQUEST_TIMEOUT_MS;
+    }
+    
+    jest.resetModules();
+  }, 10000);
+
+  it('should use default timeout when REQUEST_TIMEOUT_MS is not set', () => {
+    const originalTimeout = process.env.REQUEST_TIMEOUT_MS;
+    delete process.env.REQUEST_TIMEOUT_MS;
+
+    jest.resetModules();
+    const { REQUEST_TIMEOUT_MS } = require('../constants/timeout');
+
+    expect(REQUEST_TIMEOUT_MS).toBe(30000); 
+
+    if (originalTimeout) {
+      process.env.REQUEST_TIMEOUT_MS = originalTimeout;
+    }
+
+    jest.resetModules();
+  });
+
+  it('should cleanup timeout on response finish', async () => {
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+    app.get('/cleanup', (req: Request, res: Response) => {
+      res.json({ message: 'Success' });
+    });
+
+    await request(app).get('/cleanup');
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
##  Overview
Implements a configurable request timeout middleware that automatically terminates HTTP requests exceeding a specified duration, protecting the API from long-running requests, hanging operations, and resource exhaustion.

Closes https://github.com/Turing-dev-community/post-stack/issues/173

---

##  What Changed

### **New Files**

#### **`timeout.ts` – Main Timeout Middleware**
- Monitors all incoming requests with a configurable timeout  
- Returns **408 Request Timeout** when the threshold is exceeded  
- Automatically cleans up timers when requests complete  
- Prevents double responses using `res.headersSent` checks  

#### **`timeout.ts` – Configuration Constant**
- `REQUEST_TIMEOUT_MS` with a **default of 30 seconds**  
- Fully configurable via the `REQUEST_TIMEOUT_MS` environment variable  

#### **`timeout.test.ts` – Comprehensive Test Suite (5 tests)**
- Requests completing within timeout  
- Timeout enforcement for slow requests  
- Handles case where headers are already sent  
- Validates default configuration  
- Verifies proper timer cleanup  

---

Before gold patch
<img width="899" height="306" alt="image" src="https://github.com/user-attachments/assets/ece32553-03e7-410e-8b28-3b6e67ba89b0" />

After gold patch
<img width="927" height="310" alt="image" src="https://github.com/user-attachments/assets/9a8408de-7f41-4f30-9d46-b16388b37b72" />