### PR TITLE
feat: add Prisma middleware for slow query logging

### DIFF
--- a/src/constants/queryLogging.ts
+++ b/src/constants/queryLogging.ts
@@ -1,0 +1,16 @@
+// Database Query Logging Configuration
+
+// Default slow query threshold in milliseconds (1 second)
+export const DEFAULT_SLOW_QUERY_THRESHOLD_MS = 1000;
+
+// Configurable threshold from environment variable
+export const SLOW_QUERY_THRESHOLD_MS = process.env.SLOW_QUERY_THRESHOLD_MS
+  ? parseInt(process.env.SLOW_QUERY_THRESHOLD_MS, 10)
+  : DEFAULT_SLOW_QUERY_THRESHOLD_MS;
+
+// Whether to log all queries (not just slow ones) - useful for debugging
+export const LOG_ALL_QUERIES = process.env.LOG_ALL_QUERIES === 'true';
+
+// Whether query logging is enabled
+export const QUERY_LOGGING_ENABLED = process.env.DISABLE_QUERY_LOGGING !== 'true';
+

--- a/src/controllers/imageController.ts
+++ b/src/controllers/imageController.ts
@@ -1,7 +1,7 @@
 import { Response, Request } from "express";
 import path from "path";
 import fs from "fs";
-import { imageSize } from "image-size";
+import sizeOf from "image-size";
 import { AuthRequest } from "../utils/auth";
 
 const uploadsDir = path.join(process.cwd(), "uploads");
@@ -34,7 +34,7 @@ export const upload = async (
   // Validate image dimensions
   try {
     const imageBuffer = fs.readFileSync(filePath);
-    const dimensions = imageSize(imageBuffer);
+    const dimensions = sizeOf(imageBuffer);
     const width = dimensions.width || 0;
     const height = dimensions.height || 0;
 

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { queryLoggingMiddleware } from '../middleware/prismaQueryLogger';
 
 // Create a singleton instance of PrismaClient
 // This ensures we only have one connection pool across the application
@@ -6,11 +7,18 @@ const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
 };
 
-export const prisma =
-  globalForPrisma.prisma ??
-  new PrismaClient({
+const createPrismaClient = () => {
+  const client = new PrismaClient({
     log: process.env.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error'],
   });
+
+  // Add query logging middleware for slow query detection
+  client.$use(queryLoggingMiddleware);
+
+  return client;
+};
+
+export const prisma = globalForPrisma.prisma ?? createPrismaClient();
 
 if (process.env.NODE_ENV !== 'production') {
   globalForPrisma.prisma = prisma;

--- a/src/middleware/prismaQueryLogger.ts
+++ b/src/middleware/prismaQueryLogger.ts
@@ -1,0 +1,127 @@
+import { Prisma } from "@prisma/client";
+import {
+  SLOW_QUERY_THRESHOLD_MS,
+  LOG_ALL_QUERIES,
+  QUERY_LOGGING_ENABLED,
+} from "../constants/queryLogging";
+
+export interface QueryLogEntry {
+  model: string | undefined;
+  action: string;
+  duration: number;
+  timestamp: Date;
+  params?: string;
+  isSlow: boolean;
+}
+
+// Store for recent slow queries (useful for monitoring/debugging)
+const slowQueryLog: QueryLogEntry[] = [];
+const MAX_SLOW_QUERY_LOG_SIZE = 100;
+
+/**
+ * Get recent slow queries for monitoring purposes
+ */
+export const getSlowQueryLog = (): QueryLogEntry[] => {
+  return [...slowQueryLog];
+};
+
+/**
+ * Clear the slow query log
+ */
+export const clearSlowQueryLog = (): void => {
+  slowQueryLog.length = 0;
+};
+
+/**
+ * Format duration for display
+ */
+const formatDuration = (ms: number): string => {
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  return `${(ms / 1000).toFixed(2)}s`;
+};
+
+/**
+ * Prisma middleware for logging slow database queries
+ * Logs queries that exceed the configured threshold
+ */
+export const queryLoggingMiddleware: Prisma.Middleware = async (
+  params,
+  next
+) => {
+  // Skip if logging is disabled
+  if (!QUERY_LOGGING_ENABLED) {
+    return next(params);
+  }
+
+  const startTime = Date.now();
+
+  // Execute the query
+  const result = await next(params);
+
+  const duration = Date.now() - startTime;
+  const isSlow = duration >= SLOW_QUERY_THRESHOLD_MS;
+
+  // Create log entry
+  const logEntry: QueryLogEntry = {
+    model: params.model,
+    action: params.action,
+    duration,
+    timestamp: new Date(),
+    params: params.args ? JSON.stringify(params.args) : undefined,
+    isSlow,
+  };
+
+  // Log slow queries
+  if (isSlow) {
+    console.warn(
+      `🐢 SLOW QUERY [${formatDuration(duration)}]: ${params.model}.${
+        params.action
+      }`,
+      {
+        threshold: `${SLOW_QUERY_THRESHOLD_MS}ms`,
+        duration: `${duration}ms`,
+        model: params.model,
+        action: params.action,
+        params: params.args,
+      }
+    );
+
+    // Store in slow query log
+    slowQueryLog.push(logEntry);
+
+    // Keep log size bounded
+    if (slowQueryLog.length > MAX_SLOW_QUERY_LOG_SIZE) {
+      slowQueryLog.shift();
+    }
+  } else if (LOG_ALL_QUERIES) {
+    // Log all queries if enabled (development/debugging)
+    console.log(
+      `📊 QUERY [${formatDuration(duration)}]: ${params.model}.${params.action}`
+    );
+  }
+
+  return result;
+};
+
+/**
+ * Get query logging statistics
+ */
+export const getQueryLoggingStats = () => {
+  const slowQueries = slowQueryLog.filter((q) => q.isSlow);
+  const totalDuration = slowQueries.reduce((sum, q) => sum + q.duration, 0);
+
+  return {
+    slowQueryCount: slowQueries.length,
+    averageSlowQueryDuration:
+      slowQueries.length > 0
+        ? Math.round(totalDuration / slowQueries.length)
+        : 0,
+    slowestQuery:
+      slowQueries.length > 0
+        ? slowQueries.reduce((max, q) => (q.duration > max.duration ? q : max))
+        : null,
+    thresholdMs: SLOW_QUERY_THRESHOLD_MS,
+  };
+};

--- a/src/test/prismaQueryLogger.test.ts
+++ b/src/test/prismaQueryLogger.test.ts
@@ -1,0 +1,217 @@
+import { Prisma } from '@prisma/client';
+import {
+  queryLoggingMiddleware,
+  getSlowQueryLog,
+  clearSlowQueryLog,
+  getQueryLoggingStats,
+  QueryLogEntry,
+} from '../middleware/prismaQueryLogger';
+import {
+  DEFAULT_SLOW_QUERY_THRESHOLD_MS,
+  SLOW_QUERY_THRESHOLD_MS,
+} from '../constants/queryLogging';
+
+describe('Prisma Query Logger Middleware', () => {
+  beforeEach(() => {
+    // Clear the slow query log before each test
+    clearSlowQueryLog();
+    // Silence console output during tests
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('Configuration', () => {
+    it('should have default threshold of 1 second', () => {
+      expect(DEFAULT_SLOW_QUERY_THRESHOLD_MS).toBe(1000);
+    });
+
+    it('should export SLOW_QUERY_THRESHOLD_MS constant', () => {
+      expect(typeof SLOW_QUERY_THRESHOLD_MS).toBe('number');
+      expect(SLOW_QUERY_THRESHOLD_MS).toBeGreaterThan(0);
+    });
+  });
+
+  describe('queryLoggingMiddleware', () => {
+    it('should pass through the query and return result', async () => {
+      const mockParams = {
+        model: 'User' as Prisma.ModelName,
+        action: 'findMany' as Prisma.PrismaAction,
+        args: { where: { id: '1' } },
+        dataPath: [] as string[],
+        runInTransaction: false,
+      };
+      const mockResult = [{ id: '1', name: 'Test User' }];
+      const mockNext = jest.fn().mockResolvedValue(mockResult);
+
+      const result = await queryLoggingMiddleware(mockParams, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(mockParams);
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should log slow queries to console.warn', async () => {
+      const mockParams = {
+        model: 'Post' as Prisma.ModelName,
+        action: 'findMany' as Prisma.PrismaAction,
+        args: {},
+        dataPath: [] as string[],
+        runInTransaction: false,
+      };
+      
+      // Mock a slow query by delaying the next function
+      const mockNext = jest.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return [];
+      });
+
+      // Temporarily lower threshold for testing
+      const originalThreshold = SLOW_QUERY_THRESHOLD_MS;
+      Object.defineProperty(require('../constants/queryLogging'), 'SLOW_QUERY_THRESHOLD_MS', {
+        value: 10,
+        writable: true,
+      });
+
+      await queryLoggingMiddleware(mockParams, mockNext);
+
+      // Restore threshold
+      Object.defineProperty(require('../constants/queryLogging'), 'SLOW_QUERY_THRESHOLD_MS', {
+        value: originalThreshold,
+        writable: true,
+      });
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('should handle queries without model gracefully', async () => {
+      const mockParams = {
+        model: undefined,
+        action: 'queryRaw' as Prisma.PrismaAction,
+        args: {},
+        dataPath: [] as string[],
+        runInTransaction: false,
+      };
+      const mockResult: unknown[] = [];
+      const mockNext = jest.fn().mockResolvedValue(mockResult);
+
+      const result = await queryLoggingMiddleware(mockParams, mockNext);
+
+      expect(result).toEqual(mockResult);
+    });
+  });
+
+  describe('Slow Query Log', () => {
+    it('should start with empty log', () => {
+      const log = getSlowQueryLog();
+      expect(log).toEqual([]);
+    });
+
+    it('should clear the log correctly', () => {
+      // Manually add to log for testing
+      clearSlowQueryLog();
+      const log = getSlowQueryLog();
+      expect(log).toHaveLength(0);
+    });
+
+    it('should return a copy of the log (not the original)', () => {
+      const log1 = getSlowQueryLog();
+      const log2 = getSlowQueryLog();
+      expect(log1).not.toBe(log2);
+      expect(log1).toEqual(log2);
+    });
+  });
+
+  describe('Query Logging Stats', () => {
+    it('should return stats object with correct structure', () => {
+      const stats = getQueryLoggingStats();
+
+      expect(stats).toHaveProperty('slowQueryCount');
+      expect(stats).toHaveProperty('averageSlowQueryDuration');
+      expect(stats).toHaveProperty('slowestQuery');
+      expect(stats).toHaveProperty('thresholdMs');
+    });
+
+    it('should return zero counts when no slow queries logged', () => {
+      clearSlowQueryLog();
+      const stats = getQueryLoggingStats();
+
+      expect(stats.slowQueryCount).toBe(0);
+      expect(stats.averageSlowQueryDuration).toBe(0);
+      expect(stats.slowestQuery).toBeNull();
+    });
+
+    it('should return correct threshold from config', () => {
+      const stats = getQueryLoggingStats();
+      expect(stats.thresholdMs).toBe(SLOW_QUERY_THRESHOLD_MS);
+    });
+  });
+
+  describe('QueryLogEntry interface', () => {
+    it('should have correct shape', () => {
+      const entry: QueryLogEntry = {
+        model: 'User',
+        action: 'findMany',
+        duration: 1500,
+        timestamp: new Date(),
+        params: '{"where":{"id":"1"}}',
+        isSlow: true,
+      };
+
+      expect(entry.model).toBe('User');
+      expect(entry.action).toBe('findMany');
+      expect(entry.duration).toBe(1500);
+      expect(entry.isSlow).toBe(true);
+      expect(entry.params).toBeDefined();
+    });
+
+    it('should allow undefined model and params', () => {
+      const entry: QueryLogEntry = {
+        model: undefined,
+        action: '$queryRaw',
+        duration: 500,
+        timestamp: new Date(),
+        isSlow: false,
+      };
+
+      expect(entry.model).toBeUndefined();
+      expect(entry.params).toBeUndefined();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle empty args', async () => {
+      const mockParams = {
+        model: 'User' as Prisma.ModelName,
+        action: 'findMany' as Prisma.PrismaAction,
+        args: undefined,
+        dataPath: [] as string[],
+        runInTransaction: false,
+      };
+      const mockNext = jest.fn().mockResolvedValue([]);
+
+      const result = await queryLoggingMiddleware(mockParams, mockNext);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle errors from next function', async () => {
+      const mockParams = {
+        model: 'User' as Prisma.ModelName,
+        action: 'findMany' as Prisma.PrismaAction,
+        args: {},
+        dataPath: [] as string[],
+        runInTransaction: false,
+      };
+      const mockError = new Error('Database connection failed');
+      const mockNext = jest.fn().mockRejectedValue(mockError);
+
+      await expect(queryLoggingMiddleware(mockParams, mockNext)).rejects.toThrow(
+        'Database connection failed'
+      );
+    });
+  });
+});
+

--- a/src/test/userActivity.test.ts
+++ b/src/test/userActivity.test.ts
@@ -1,3 +1,12 @@
+import { PrismaClient } from '@prisma/client';
+import { mockDeep } from 'jest-mock-extended';
+
+// Mock prisma before importing it
+jest.mock('../lib/prisma', () => ({
+  __esModule: true,
+  prisma: mockDeep<PrismaClient>(),
+}));
+
 import request from 'supertest';
 import { setupPrismaMock } from './utils/mockPrisma';
 import { prisma } from '../lib/prisma';


### PR DESCRIPTION
## Summary

Adds Prisma middleware to log database queries that exceed a configurable time threshold, helping identify performance bottlenecks.
fixes #172 
## Changes

- Added src/constants/queryLogging.ts - Configurable threshold constants

- Added src/middleware/prismaQueryLogger.ts - Query logging middleware

- Updated src/lib/prisma.ts - Integrated middleware with Prisma client

- Added src/test/prismaQueryLogger.test.ts - Unit tests (15 test cases)

- Fixed src/test/userActivity.test.ts - Added explicit Jest mock for proper test isolation

## What it does

- Measures execution time of every database query

- Logs warning when queries exceed threshold (default: 1 second)

- Stores slow queries in memory for diagnostics

- Provides statistics function for monitoring

## Console Output

🐢 SLOW QUERY [1.25s]: Post.findMany {

  threshold: '1000ms',

  duration: '1250ms',

  model: 'Post',

  action: 'findMany',

  params: { where: { published: true } }

}

## Configuration

|Environment Variable|Default|Description|
|---|---|---|
|SLOW_QUERY_THRESHOLD_MS|1000|Threshold in milliseconds|
|LOG_ALL_QUERIES|false|Log all queries (not just slow)|
|DISABLE_QUERY_LOGGING|false|Disable logging entirely|

Before golden patch 
<img width="1456" height="372" alt="image" src="https://github.com/user-attachments/assets/be69a7c7-12a4-484e-8748-f94a557a00a3" />

After golden patch 
<img width="1467" height="599" alt="image" src="https://github.com/user-attachments/assets/a7b7e88a-5918-4c89-8803-fd406d71dccd" />
