### PR TITLE
Feat: Post Cloning/Duplication

### DIFF
--- a/src/controllers/posts/postsCrudController.ts
+++ b/src/controllers/posts/postsCrudController.ts
@@ -287,3 +287,36 @@ export async function bulkCreatePosts(
 		throw error;
 	}
 }
+
+/**
+ * Clone an existing post as a new draft
+ */
+export async function clonePost(
+	req: AuthRequest,
+	res: Response
+): Promise<Response> {
+	if (!checkAuth(req, res)) return res as Response;
+
+	const { postId } = req.params;
+
+	try {
+		const post = await postsService.clonePost(postId, req.user.id);
+
+		return res.status(201).json({
+			message: "Post cloned successfully",
+			post,
+		});
+	} catch (error: any) {
+		if (error.message === "Post not found") {
+			return res.status(404).json({
+				error: "Post not found",
+			});
+		}
+		if (error.message === "Not authorized to clone this post") {
+			return res.status(403).json({
+				error: "Not authorized to clone this post",
+			});
+		}
+		throw error;
+	}
+}

--- a/src/routes/posts.ts
+++ b/src/routes/posts.ts
@@ -117,7 +117,7 @@ router.post(
 
 // Create multiple posts in bulk
 router.post('/bulk', validateBulkPosts, authenticateToken, requireAuthor, handleValidationErrors, asyncHandler(
-  (req: AuthRequest, res: Response) => postsController.bulkCreatePosts(req, res)
+	(req: AuthRequest, res: Response) => postsController.bulkCreatePosts(req, res)
 ));
 
 // Update post
@@ -210,6 +210,15 @@ router.delete(
 	authenticateToken,
 	asyncHandler((req: AuthRequest, res: Response) =>
 		postsController.unschedulePost(req, res)
+	)
+);
+
+// Clone a post as a new draft
+router.post(
+	"/:postId/clone",
+	authenticateToken,
+	asyncHandler((req: AuthRequest, res: Response) =>
+		postsController.clonePost(req, res)
 	)
 );
 

--- a/src/services/posts/index.ts
+++ b/src/services/posts/index.ts
@@ -21,7 +21,7 @@ export {
 } from "./postsQueryService";
 
 // Export CRUD services
-export { createPost, updatePost, deletePost, bulkCreatePosts, schedulePost, unschedulePost } from "./postsCrudService";
+export { createPost, updatePost, deletePost, bulkCreatePosts, schedulePost, unschedulePost, clonePost } from "./postsCrudService";
 
 // Export interaction services
 export {

--- a/src/test/postClone.test.ts
+++ b/src/test/postClone.test.ts
@@ -1,0 +1,316 @@
+import request from "supertest";
+import { PrismaClient } from "@prisma/client";
+import { mockDeep, mockReset, DeepMockProxy } from "jest-mock-extended";
+import jwt from "jsonwebtoken";
+
+// Mock the prisma module before importing app
+jest.mock("../lib/prisma", () => ({
+    __esModule: true,
+    prisma: mockDeep<PrismaClient>(),
+}));
+
+import { prisma } from "../lib/prisma";
+import app from "../index";
+
+const prismaMock = prisma as unknown as DeepMockProxy<PrismaClient>;
+
+// Helper to create a valid JWT token
+const createTestToken = (userId: string) => {
+    return jwt.sign({ userId }, process.env.JWT_SECRET || "test-secret", {
+        expiresIn: "1h",
+    });
+};
+
+describe("POST /api/posts/:postId/clone", () => {
+    beforeEach(() => {
+        mockReset(prismaMock);
+    });
+
+    const mockUser = {
+        id: "user-1",
+        email: "test@example.com",
+        username: "testuser",
+        password: "hashedpassword",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        about: null,
+        profilePicture: null,
+        deletedAt: null,
+        failedLoginAttempts: 0,
+        lockedUntil: null,
+    };
+
+    const mockOriginalPost = {
+        id: "post-1",
+        title: "Original Post",
+        content: "This is the original content",
+        slug: "original-post",
+        published: true,
+        featured: true,
+        authorId: "user-1",
+        categoryId: "cat-1",
+        metaTitle: "Original Meta Title",
+        metaDescription: "Original Meta Description",
+        ogImage: "https://example.com/og.jpg",
+        excerpt: "Original excerpt",
+        featuredImage: "https://example.com/featured.jpg",
+        viewCount: 100,
+        allowComments: true,
+        scheduledAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        tags: [
+            {
+                id: "pt-1",
+                postId: "post-1",
+                tagId: "tag-1",
+                createdAt: new Date(),
+                tag: {
+                    id: "tag-1",
+                    name: "JavaScript",
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+            },
+        ],
+        author: {
+            id: "user-1",
+            username: "testuser",
+        },
+        category: {
+            id: "cat-1",
+            name: "Technology",
+            slug: "technology",
+        },
+    };
+
+    const mockClonedPost = {
+        id: "post-2",
+        title: "Original Post (Copy)",
+        content: "This is the original content",
+        slug: "original-post-copy",
+        published: false,
+        featured: false,
+        authorId: "user-1",
+        categoryId: "cat-1",
+        metaTitle: "Original Meta Title",
+        metaDescription: "Original Meta Description",
+        ogImage: "https://example.com/og.jpg",
+        excerpt: "Original excerpt",
+        featuredImage: "https://example.com/featured.jpg",
+        viewCount: 0,
+        allowComments: true,
+        scheduledAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        tags: [
+            {
+                id: "pt-2",
+                postId: "post-2",
+                tagId: "tag-1",
+                createdAt: new Date(),
+                tag: {
+                    id: "tag-1",
+                    name: "JavaScript",
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+            },
+        ],
+        author: {
+            id: "user-1",
+            username: "testuser",
+        },
+        category: {
+            id: "cat-1",
+            name: "Technology",
+            slug: "technology",
+        },
+    };
+
+    it("should clone a post successfully", async () => {
+        const token = createTestToken("user-1");
+
+        // Mock user lookup for auth
+        (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+
+        // Mock finding posts - returns original post for id lookup, null for slug lookup (no collision)
+        (prismaMock.post.findUnique as jest.Mock).mockImplementation((args: any) => {
+            if (args.where.id === "post-1") {
+                return Promise.resolve(mockOriginalPost);
+            }
+            // Slug lookup for collision check - return null (no collision)
+            if (args.where.slug) {
+                return Promise.resolve(null);
+            }
+            return Promise.resolve(null);
+        });
+
+        // Mock creating the cloned post
+        (prismaMock.post.create as jest.Mock).mockResolvedValue(mockClonedPost);
+
+        // Mock like count
+        (prismaMock.postLike.count as jest.Mock).mockResolvedValue(0);
+
+        const response = await request(app)
+            .post("/api/posts/post-1/clone")
+            .set("Authorization", `Bearer ${token}`);
+
+        expect(response.status).toBe(201);
+        expect(response.body.message).toBe("Post cloned successfully");
+        expect(response.body.post).toBeDefined();
+        expect(response.body.post.title).toBe("Original Post (Copy)");
+        expect(response.body.post.published).toBe(false);
+        expect(response.body.post.featured).toBe(false);
+    });
+
+    it("should return 404 if post to clone is not found", async () => {
+        const token = createTestToken("user-1");
+
+        (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+        (prismaMock.post.findUnique as jest.Mock).mockResolvedValue(null);
+
+        const response = await request(app)
+            .post("/api/posts/non-existent-post/clone")
+            .set("Authorization", `Bearer ${token}`);
+
+        expect(response.status).toBe(404);
+        expect(response.body.error).toBe("Post not found");
+    });
+
+    it("should return 401 if not authenticated", async () => {
+        const response = await request(app).post("/api/posts/post-1/clone");
+
+        expect(response.status).toBe(401);
+    });
+
+    it("should create cloned post as unpublished draft", async () => {
+        const token = createTestToken("user-1");
+
+        (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+        (prismaMock.post.findUnique as jest.Mock).mockImplementation((args: any) => {
+            if (args.where.id === "post-1") return Promise.resolve(mockOriginalPost);
+            return Promise.resolve(null);
+        });
+        (prismaMock.post.create as jest.Mock).mockResolvedValue(mockClonedPost);
+        (prismaMock.postLike.count as jest.Mock).mockResolvedValue(0);
+
+        const response = await request(app)
+            .post("/api/posts/post-1/clone")
+            .set("Authorization", `Bearer ${token}`);
+
+        expect(response.status).toBe(201);
+        expect(response.body.post.published).toBe(false);
+        expect(response.body.post.featured).toBe(false);
+    });
+
+    it("should copy tags from original post", async () => {
+        const token = createTestToken("user-1");
+
+        (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+        (prismaMock.post.findUnique as jest.Mock).mockImplementation((args: any) => {
+            if (args.where.id === "post-1") return Promise.resolve(mockOriginalPost);
+            return Promise.resolve(null);
+        });
+        (prismaMock.post.create as jest.Mock).mockResolvedValue(mockClonedPost);
+        (prismaMock.postLike.count as jest.Mock).mockResolvedValue(0);
+
+        const response = await request(app)
+            .post("/api/posts/post-1/clone")
+            .set("Authorization", `Bearer ${token}`);
+
+        expect(response.status).toBe(201);
+        expect(response.body.post.tags).toBeDefined();
+        expect(response.body.post.tags.length).toBe(1);
+        expect(response.body.post.tags[0].name).toBe("JavaScript");
+    });
+
+    it("should generate a new unique slug with (Copy) suffix", async () => {
+        const token = createTestToken("user-1");
+
+        (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+        (prismaMock.post.findUnique as jest.Mock).mockImplementation((args: any) => {
+            if (args.where.id === "post-1") return Promise.resolve(mockOriginalPost);
+            return Promise.resolve(null);
+        });
+        (prismaMock.post.create as jest.Mock).mockResolvedValue(mockClonedPost);
+        (prismaMock.postLike.count as jest.Mock).mockResolvedValue(0);
+
+        const response = await request(app)
+            .post("/api/posts/post-1/clone")
+            .set("Authorization", `Bearer ${token}`);
+
+        expect(response.status).toBe(201);
+        expect(response.body.post.title).toContain("(Copy)");
+        expect(response.body.post.slug).not.toBe(mockOriginalPost.slug);
+    });
+
+    it("should copy content and metadata from original post", async () => {
+        const token = createTestToken("user-1");
+
+        (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+        (prismaMock.post.findUnique as jest.Mock).mockImplementation((args: any) => {
+            if (args.where.id === "post-1") return Promise.resolve(mockOriginalPost);
+            return Promise.resolve(null);
+        });
+        (prismaMock.post.create as jest.Mock).mockResolvedValue(mockClonedPost);
+        (prismaMock.postLike.count as jest.Mock).mockResolvedValue(0);
+
+        const response = await request(app)
+            .post("/api/posts/post-1/clone")
+            .set("Authorization", `Bearer ${token}`);
+
+        expect(response.status).toBe(201);
+        expect(response.body.post.content).toBe(mockOriginalPost.content);
+        expect(response.body.post.metaTitle).toBe(mockOriginalPost.metaTitle);
+        expect(response.body.post.metaDescription).toBe(mockOriginalPost.metaDescription);
+    });
+
+    it("should set the current user as the author of the cloned post", async () => {
+        const token = createTestToken("user-1");
+
+        (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+        (prismaMock.post.findUnique as jest.Mock).mockImplementation((args: any) => {
+            if (args.where.id === "post-1") return Promise.resolve(mockOriginalPost);
+            return Promise.resolve(null);
+        });
+        (prismaMock.post.create as jest.Mock).mockResolvedValue(mockClonedPost);
+        (prismaMock.postLike.count as jest.Mock).mockResolvedValue(0);
+
+        const response = await request(app)
+            .post("/api/posts/post-1/clone")
+            .set("Authorization", `Bearer ${token}`);
+
+        expect(response.status).toBe(201);
+        expect(response.body.post.authorId).toBe("user-1");
+    });
+
+    it("should return 403 when trying to clone another user's post", async () => {
+        const token = createTestToken("user-2"); // Different user
+
+        const mockUser2 = {
+            ...mockUser,
+            id: "user-2",
+            email: "user2@example.com",
+            username: "testuser2",
+        };
+
+        const postByAnotherUser = {
+            ...mockOriginalPost,
+            authorId: "user-1", // Post belongs to user-1, not user-2
+        };
+
+        (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockUser2);
+        (prismaMock.post.findUnique as jest.Mock).mockImplementation((args: any) => {
+            if (args.where.id === "post-1") return Promise.resolve(postByAnotherUser);
+            return Promise.resolve(null);
+        });
+
+        const response = await request(app)
+            .post("/api/posts/post-1/clone")
+            .set("Authorization", `Bearer ${token}`);
+
+        expect(response.status).toBe(403);
+        expect(response.body.error).toBe("Not authorized to clone this post");
+    });
+});


### PR DESCRIPTION
### Summary
Adds the ability for authors to clone their own posts as new drafts via `POST /api/posts/:postId/clone`.

### Changes

**New Files:**
- `src/test/postClone.test.ts` - 9 test cases for the clone feature

**Modified Files:**
- `src/services/posts/postsCrudService.ts` - Added `clonePost()` service function
- `src/services/posts/index.ts` - Export `clonePost`
- `src/controllers/posts/postsCrudController.ts` - Added `clonePost()` controller
- `src/routes/posts.ts` - Added `POST /:postId/clone` route

### How It Works
1. User sends `POST /api/posts/:postId/clone` with auth token
2. Service verifies post exists and user is the owner
3. Creates a new draft post with:
   - Title suffixed with "(Copy)"
   - Unique slug generated via `generateUniquePostSlug()`
   - Copied: content, metadata, category, tags
   - Reset: `published=false`, `featured=false`, `viewCount=0`
4. Returns the cloned post with 201 status

### API
```
POST /api/posts/:postId/clone
Authorization: Bearer <token>

201: { message: "Post cloned successfully", post: {...} }
401: Unauthorized
403: Not authorized to clone this post
404: Post not found
```

### Testing
All 9 tests passing:
- ✅ Clone post successfully
- ✅ 404 for non-existent post
- ✅ 401 for unauthenticated request
- ✅ 403 for cloning another user's post
- ✅ Cloned post is unpublished draft
- ✅ Tags are copied
- ✅ Unique slug generated
- ✅ Content/metadata copied
- ✅ Current user set as author

### Checklist
- [x] Code follows project patterns
- [x] Authorization check implemented
- [x] Tests added and passing
- [x] Cache invalidation handled

## Related Issue
Closes #181 

## Screen Shots:

### Before:
<img width="1088" height="569" alt="post-clone-before" src="https://github.com/user-attachments/assets/a96c3c86-26b6-47ff-aaac-7bad8a5b2ff7" />


### After:

<img width="1088" height="572" alt="post-clone-after" src="https://github.com/user-attachments/assets/3cdd0d76-1f95-4211-b12c-72874edf1cad" />


## Eval Tool Link

https://eval.turing.com/conversations/217228/view