### PR TITLE
FEAT: Comment Pinning by Post Author

### DIFF
--- a/src/routes/comments.ts
+++ b/src/routes/comments.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { authenticateToken } from '../utils/auth';
 import { validateComment, validateCommentReport } from '../middleware/validators';
 import { handleValidationErrors } from '../middleware/validation';
-import { 
+import {
   getCommentsForPost,
   createComment,
   replyToComment,
@@ -13,6 +13,8 @@ import {
   reportComment,
   moderateComment,
   getModerationQueue,
+  pinComment,
+  unpinComment,
 } from '../controllers/commentsController';
 
 const router = Router();
@@ -79,6 +81,20 @@ router.get(
   '/:postId/moderation-queue',
   authenticateToken,
   getModerationQueue
+);
+
+// Pin a comment to the top of a post
+router.post(
+  '/:postId/comments/:commentId/pin',
+  authenticateToken,
+  pinComment
+);
+
+// Unpin a comment from the top of a post
+router.delete(
+  '/:postId/comments/:commentId/pin',
+  authenticateToken,
+  unpinComment
 );
 
 export default router;

--- a/src/test/commentPin.test.ts
+++ b/src/test/commentPin.test.ts
@@ -1,0 +1,206 @@
+import request from 'supertest';
+import { setupPrismaMock } from './utils/mockPrisma';
+import { prisma } from '../lib/prisma';
+import app from '../index';
+import { generateToken } from '../utils/auth';
+
+const { prisma: prismaMock } = setupPrismaMock(prisma, app);
+
+describe('Comment Pinning API', () => {
+    const authorId = 'author-1';
+    const otherUserId = 'user-2';
+    const postId = 'post-1';
+    const commentId = 'comment-1';
+
+    const authorToken = (() => {
+        process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret';
+        return generateToken(authorId);
+    })();
+
+    const otherUserToken = (() => {
+        return generateToken(otherUserId);
+    })();
+
+    const mockAuthor = {
+        id: authorId,
+        email: 'author@example.com',
+        username: 'author',
+        deletedAt: null,
+    };
+
+    const mockOtherUser = {
+        id: otherUserId,
+        email: 'other@example.com',
+        username: 'otheruser',
+        deletedAt: null,
+    };
+
+    const mockPost = {
+        id: postId,
+        title: 'Test Post',
+        slug: 'test-post',
+        authorId: authorId,
+        pinnedCommentId: null,
+    };
+
+    const mockComment = {
+        id: commentId,
+        content: 'This is a test comment',
+        postId: postId,
+        userId: otherUserId,
+        parentId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    };
+
+    describe('POST /:postId/comments/:commentId/pin', () => {
+        it('should pin a comment successfully when user is post author', async () => {
+            (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockAuthor);
+            (prismaMock.post.findUnique as jest.Mock).mockResolvedValue(mockPost);
+            (prismaMock.comment.findUnique as jest.Mock).mockResolvedValue(mockComment);
+            (prismaMock.post.update as jest.Mock).mockResolvedValue({
+                ...mockPost,
+                pinnedCommentId: commentId,
+            });
+
+            const res = await request(app)
+                .post(`/api/posts/${postId}/comments/${commentId}/pin`)
+                .set('Authorization', `Bearer ${authorToken}`)
+                .expect(200);
+
+            expect(res.body).toHaveProperty('message', 'Comment pinned successfully');
+            expect(res.body).toHaveProperty('pinnedCommentId', commentId);
+        });
+
+        it('should return 403 when trying to pin a comment on another user\'s post', async () => {
+            (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockOtherUser);
+            (prismaMock.post.findUnique as jest.Mock).mockResolvedValue(mockPost);
+
+            const res = await request(app)
+                .post(`/api/posts/${postId}/comments/${commentId}/pin`)
+                .set('Authorization', `Bearer ${otherUserToken}`)
+                .expect(403);
+
+            expect(res.body).toHaveProperty('error', 'ForbiddenError');
+            expect(res.body).toHaveProperty('message', 'Only the post author can pin comments');
+        });
+
+        it('should return 404 when post does not exist', async () => {
+            (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockAuthor);
+            (prismaMock.post.findUnique as jest.Mock).mockResolvedValue(null);
+
+            const res = await request(app)
+                .post(`/api/posts/non-existent/comments/${commentId}/pin`)
+                .set('Authorization', `Bearer ${authorToken}`)
+                .expect(404);
+
+            expect(res.body).toHaveProperty('error', 'NotFoundError');
+            expect(res.body).toHaveProperty('message', 'Post not found');
+        });
+
+        it('should return 404 when comment does not exist', async () => {
+            (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockAuthor);
+            (prismaMock.post.findUnique as jest.Mock).mockResolvedValue(mockPost);
+            (prismaMock.comment.findUnique as jest.Mock).mockResolvedValue(null);
+
+            const res = await request(app)
+                .post(`/api/posts/${postId}/comments/non-existent/pin`)
+                .set('Authorization', `Bearer ${authorToken}`)
+                .expect(404);
+
+            expect(res.body).toHaveProperty('error', 'NotFoundError');
+            expect(res.body).toHaveProperty('message', 'Comment not found');
+        });
+
+        it('should return 404 when comment does not belong to the post', async () => {
+            (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockAuthor);
+            (prismaMock.post.findUnique as jest.Mock).mockResolvedValue(mockPost);
+            (prismaMock.comment.findUnique as jest.Mock).mockResolvedValue({
+                ...mockComment,
+                postId: 'other-post-id',
+            });
+
+            const res = await request(app)
+                .post(`/api/posts/${postId}/comments/${commentId}/pin`)
+                .set('Authorization', `Bearer ${authorToken}`)
+                .expect(404);
+
+            expect(res.body).toHaveProperty('error', 'NotFoundError');
+            expect(res.body).toHaveProperty('message', 'Comment does not belong to this post');
+        });
+
+        it('should return 401 when not authenticated', async () => {
+            const res = await request(app)
+                .post(`/api/posts/${postId}/comments/${commentId}/pin`)
+                .expect(401);
+
+            expect(res.body).toHaveProperty('error', 'Access token required');
+        });
+    });
+
+    describe('DELETE /:postId/comments/:commentId/pin', () => {
+        it('should unpin a comment successfully', async () => {
+            (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockAuthor);
+            (prismaMock.post.findUnique as jest.Mock).mockResolvedValue({
+                ...mockPost,
+                pinnedCommentId: commentId,
+            });
+            (prismaMock.post.update as jest.Mock).mockResolvedValue({
+                ...mockPost,
+                pinnedCommentId: null,
+            });
+
+            const res = await request(app)
+                .delete(`/api/posts/${postId}/comments/${commentId}/pin`)
+                .set('Authorization', `Bearer ${authorToken}`)
+                .expect(200);
+
+            expect(res.body).toHaveProperty('message', 'Comment unpinned successfully');
+        });
+
+        it('should return 400 when no comment is pinned', async () => {
+            (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockAuthor);
+            (prismaMock.post.findUnique as jest.Mock).mockResolvedValue(mockPost);
+
+            const res = await request(app)
+                .delete(`/api/posts/${postId}/comments/${commentId}/pin`)
+                .set('Authorization', `Bearer ${authorToken}`)
+                .expect(400);
+
+            expect(res.body).toHaveProperty('error', 'BadRequestError');
+            expect(res.body).toHaveProperty('message', 'No comment is currently pinned');
+        });
+
+        it('should return 400 when trying to unpin a different comment', async () => {
+            (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockAuthor);
+            (prismaMock.post.findUnique as jest.Mock).mockResolvedValue({
+                ...mockPost,
+                pinnedCommentId: 'other-comment-id',
+            });
+
+            const res = await request(app)
+                .delete(`/api/posts/${postId}/comments/${commentId}/pin`)
+                .set('Authorization', `Bearer ${authorToken}`)
+                .expect(400);
+
+            expect(res.body).toHaveProperty('error', 'BadRequestError');
+            expect(res.body).toHaveProperty('message', 'This comment is not pinned');
+        });
+
+        it('should return 403 when trying to unpin on another user\'s post', async () => {
+            (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockOtherUser);
+            (prismaMock.post.findUnique as jest.Mock).mockResolvedValue({
+                ...mockPost,
+                pinnedCommentId: commentId,
+            });
+
+            const res = await request(app)
+                .delete(`/api/posts/${postId}/comments/${commentId}/pin`)
+                .set('Authorization', `Bearer ${otherUserToken}`)
+                .expect(403);
+
+            expect(res.body).toHaveProperty('error', 'ForbiddenError');
+            expect(res.body).toHaveProperty('message', 'Only the post author can unpin comments');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Adds the ability for post authors to pin one comment to the top of their post via `POST/DELETE /api/posts/:postId/comments/:commentId/pin`.

## Changes

**New Files:**
- `src/test/commentPin.test.ts` - 10 test cases for pin/unpin functionality

**Modified Files:**
- `src/controllers/commentsController.ts` - Added `pinComment()` and `unpinComment()` functions
- `src/routes/comments.ts` - Added routes for pin/unpin endpoints

## How It Works
1. User sends `POST /api/posts/:postId/comments/:commentId/pin` with auth token
2. Controller verifies user is the post author
3. Controller verifies comment exists and belongs to the post
4. Updates post's `pinnedCommentId` field
5. Invalidates cache and returns success response

## API
```
POST   /api/posts/:postId/comments/:commentId/pin  - Pin a comment
DELETE /api/posts/:postId/comments/:commentId/pin  - Unpin a comment

Authorization: Bearer <token>

Responses:
200: { message: "Comment pinned/unpinned successfully" }
400: Bad Request (no comment pinned / wrong comment)
401: Unauthorized
403: Only post author can pin/unpin
404: Post/Comment not found
```

## Testing
All 10 tests passing:
- ✅ Pin comment successfully as post author
- ✅ 403 when pinning on another user's post
- ✅ 404 when post doesn't exist
- ✅ 404 when comment doesn't exist
- ✅ 404 when comment doesn't belong to post
- ✅ 401 when not authenticated
- ✅ Unpin comment successfully
- ✅ 400 when no comment is pinned
- ✅ 400 when trying to unpin different comment
- ✅ 403 when unpinning on another user's post

## Checklist
- [x] Code follows project patterns
- [x] Uses `ResponseHandler` for responses
- [x] Uses proper error types (`NotFoundError`, `ForbiddenError`, `BadRequestError`)
- [x] No `any` types used
- [x] Authorization checks implemented
- [x] Cache invalidation handled
- [x] Tests added and passing


## Related Issue:

Closes #185

## Screenshots:

### Before:
<img width="1089" height="576" alt="comment-pin-before" src="https://github.com/user-attachments/assets/9d4f13be-6540-4c98-af9f-7210904f7c8a" />

### After:
<img width="1085" height="573" alt="comment-pin-after" src="https://github.com/user-attachments/assets/6853287f-1afd-4af9-9b95-91bac8b0975f" />


## Eval Tool Link:

https://eval.turing.com/conversations/217229/view
