### PR TITLE
FEAT:Author Verification/Badge System

### DIFF
--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { authenticateToken } from '../utils/auth';
-import { followUser, unfollowUser, getFollowers, getFollowing, getUserActivity, getUserPublicProfile, deleteUser } from '../controllers/usersController';
+import { followUser, unfollowUser, getFollowers, getFollowing, getUserActivity, getUserPublicProfile, deleteUser, verifyUser, unverifyUser } from '../controllers/usersController';
 import { validatePagination } from '../middleware/validators';
 import { handleValidationErrors } from '../middleware/validation';
 import { cacheMiddleware } from '../middleware/cache';
@@ -52,6 +52,19 @@ router.get(
 router.delete(
   '/',
   deleteUser
+);
+
+// Admin-only routes: User verification
+router.patch(
+  '/:userId/verify',
+  authenticateToken,
+  verifyUser
+);
+
+router.delete(
+  '/:userId/verify',
+  authenticateToken,
+  unverifyUser
 );
 
 export default router;

--- a/src/test/userVerification.test.ts
+++ b/src/test/userVerification.test.ts
@@ -1,0 +1,163 @@
+import request from 'supertest';
+import { setupPrismaMock } from './utils/mockPrisma';
+import { prisma } from '../lib/prisma';
+import app from '../index';
+import { generateToken } from '../utils/auth';
+
+const { prisma: prismaMock } = setupPrismaMock(prisma, app);
+
+describe('User Verification API', () => {
+    const adminId = 'admin-1';
+    const userId = 'user-1';
+    const targetUserId = 'user-2';
+
+    const adminToken = (() => {
+        process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret';
+        return generateToken(adminId);
+    })();
+
+    const userToken = (() => {
+        return generateToken(userId);
+    })();
+
+    const mockAdmin = {
+        id: adminId,
+        email: 'admin@example.com',
+        username: 'admin',
+        deletedAt: null,
+    };
+
+    const mockUser = {
+        id: userId,
+        email: 'user@example.com',
+        username: 'testuser',
+        deletedAt: null,
+    };
+
+    const mockTargetUser = {
+        id: targetUserId,
+        email: 'target@example.com',
+        username: 'targetuser',
+        deletedAt: null,
+        isVerified: false,
+    };
+
+    beforeEach(() => {
+        // Set admin email for admin tests
+        process.env.ADMIN_EMAILS = 'admin@example.com';
+    });
+
+    afterEach(() => {
+        delete process.env.ADMIN_EMAILS;
+    });
+
+    describe('PATCH /:userId/verify', () => {
+        it('should verify a user successfully when admin', async () => {
+            (prismaMock.user.findUnique as jest.Mock).mockImplementation(({ where }) => {
+                if (where.id === adminId) return Promise.resolve(mockAdmin);
+                if (where.id === targetUserId) return Promise.resolve(mockTargetUser);
+                return Promise.resolve(null);
+            });
+            (prismaMock.user.update as jest.Mock).mockResolvedValue({
+                ...mockTargetUser,
+                isVerified: true,
+            });
+
+            const res = await request(app)
+                .patch(`/api/users/${targetUserId}/verify`)
+                .set('Authorization', `Bearer ${adminToken}`)
+                .expect(200);
+
+            expect(res.body).toHaveProperty('message', 'User verified successfully');
+            expect(res.body).toHaveProperty('isVerified', true);
+        });
+
+        it('should return 403 when non-admin tries to verify', async () => {
+            (prismaMock.user.findUnique as jest.Mock).mockImplementation(({ where }) => {
+                if (where.id === userId) return Promise.resolve(mockUser);
+                return Promise.resolve(null);
+            });
+
+            const res = await request(app)
+                .patch(`/api/users/${targetUserId}/verify`)
+                .set('Authorization', `Bearer ${userToken}`)
+                .expect(403);
+
+            expect(res.body).toHaveProperty('error', 'Admin access required');
+        });
+
+        it('should return 404 when user does not exist', async () => {
+            (prismaMock.user.findUnique as jest.Mock).mockImplementation(({ where }) => {
+                if (where.id === adminId) return Promise.resolve(mockAdmin);
+                return Promise.resolve(null);
+            });
+
+            const res = await request(app)
+                .patch('/api/users/non-existent/verify')
+                .set('Authorization', `Bearer ${adminToken}`)
+                .expect(404);
+
+            expect(res.body).toHaveProperty('error', 'NotFoundError');
+            expect(res.body).toHaveProperty('message', 'User not found');
+        });
+
+        it('should return 401 when not authenticated', async () => {
+            const res = await request(app)
+                .patch(`/api/users/${targetUserId}/verify`)
+                .expect(401);
+
+            expect(res.body).toHaveProperty('error', 'Access token required');
+        });
+    });
+
+    describe('DELETE /:userId/verify', () => {
+        it('should unverify a user successfully when admin', async () => {
+            (prismaMock.user.findUnique as jest.Mock).mockImplementation(({ where }) => {
+                if (where.id === adminId) return Promise.resolve(mockAdmin);
+                if (where.id === targetUserId) return Promise.resolve({ ...mockTargetUser, isVerified: true });
+                return Promise.resolve(null);
+            });
+            (prismaMock.user.update as jest.Mock).mockResolvedValue({
+                ...mockTargetUser,
+                isVerified: false,
+            });
+
+            const res = await request(app)
+                .delete(`/api/users/${targetUserId}/verify`)
+                .set('Authorization', `Bearer ${adminToken}`)
+                .expect(200);
+
+            expect(res.body).toHaveProperty('message', 'User unverified successfully');
+            expect(res.body).toHaveProperty('isVerified', false);
+        });
+
+        it('should return 403 when non-admin tries to unverify', async () => {
+            (prismaMock.user.findUnique as jest.Mock).mockImplementation(({ where }) => {
+                if (where.id === userId) return Promise.resolve(mockUser);
+                return Promise.resolve(null);
+            });
+
+            const res = await request(app)
+                .delete(`/api/users/${targetUserId}/verify`)
+                .set('Authorization', `Bearer ${userToken}`)
+                .expect(403);
+
+            expect(res.body).toHaveProperty('error', 'Admin access required');
+        });
+
+        it('should return 404 when user does not exist', async () => {
+            (prismaMock.user.findUnique as jest.Mock).mockImplementation(({ where }) => {
+                if (where.id === adminId) return Promise.resolve(mockAdmin);
+                return Promise.resolve(null);
+            });
+
+            const res = await request(app)
+                .delete('/api/users/non-existent/verify')
+                .set('Authorization', `Bearer ${adminToken}`)
+                .expect(404);
+
+            expect(res.body).toHaveProperty('error', 'NotFoundError');
+            expect(res.body).toHaveProperty('message', 'User not found');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Adds admin-only endpoints for verifying/unverifying users via `PATCH/DELETE /api/users/:userId/verify`.

## Changes

**New Files:**
- `src/test/userVerification.test.ts` - 7 test cases for verification functionality

**Modified Files:**
- `src/controllers/usersController.ts` - Added `verifyUser()` and `unverifyUser()` functions
- `src/routes/users.ts` - Added routes for verify/unverify endpoints

## API
```
PATCH  /api/users/:userId/verify  - Verify a user (Admin only)
DELETE /api/users/:userId/verify  - Unverify a user (Admin only)

Authorization: Bearer <token>

Responses:
200: { message: "User verified/unverified successfully", isVerified: boolean }
401: Unauthorized
403: Admin access required
404: User not found
```

## Testing
All 7 tests passing:
- ✅ Admin verifies user successfully
- ✅ 403 when non-admin tries to verify
- ✅ 404 when user doesn't exist
- ✅ 401 when not authenticated
- ✅ Admin unverifies user successfully
- ✅ 403 when non-admin tries to unverify
- ✅ 404 when user doesn't exist (unverify)

## Checklist
- [x] Uses `checkAdmin` for authorization
- [x] Uses `ResponseHandler` for responses
- [x] No `any` types used
- [x] Tests added and passing

## Related Issue:
Close #187

## Screenshot:
### Before:
<img width="956" height="536" alt="verification-badge-before" src="https://github.com/user-attachments/assets/2fe2eb29-530e-4d40-9480-464b1342d83b" />

### After:
<img width="959" height="544" alt="verification-badge-after" src="https://github.com/user-attachments/assets/2cab76c6-262d-4dea-a5cb-4aae61c079f8" />

## Eval Tool Link: 
https://eval.turing.com/conversations/217235/view