### PR TITLE
BUG: Image Cleanup on Post Delete

### DIFF
--- a/src/routes/images.ts
+++ b/src/routes/images.ts
@@ -8,6 +8,8 @@ import { requireAuthor } from "../middleware/authorization";
 import {
 	upload as uploadController,
 	get as getController,
+	getOrphanedImages as getOrphanedImagesController,
+	deleteOrphanedImages as deleteOrphanedImagesController,
 } from "../controllers/imageController";
 
 const router = Router();
@@ -87,7 +89,7 @@ router.use((error: any, req: Request, res: Response, next: any): void => {
 	if (
 		error &&
 		error.message ===
-			"Invalid file type. Only JPEG, PNG, GIF, and WebP images are allowed."
+		"Invalid file type. Only JPEG, PNG, GIF, and WebP images are allowed."
 	) {
 		res.status(400).json({
 			error: "Invalid file type",
@@ -98,6 +100,22 @@ router.use((error: any, req: Request, res: Response, next: any): void => {
 	next(error);
 });
 
+// Orphaned image management routes (admin only)
+router.get(
+	"/orphaned",
+	authenticateToken,
+	requireAuthor,
+	asyncHandler(getOrphanedImagesController)
+);
+
+router.delete(
+	"/orphaned",
+	authenticateToken,
+	requireAuthor,
+	asyncHandler(deleteOrphanedImagesController)
+);
+
+// This route must come last as it's a catch-all pattern
 router.get("/:filename", asyncHandler(getController));
 
 export default router;

--- a/src/services/imageCleanupService.ts
+++ b/src/services/imageCleanupService.ts
@@ -1,0 +1,159 @@
+import fs from 'fs';
+import path from 'path';
+import { prisma } from '../lib/prisma';
+
+const uploadsDir = path.join(process.cwd(), 'uploads');
+
+/**
+ * Extract image filename from an image path
+ * Handles both full paths (/api/images/filename.jpg) and just filenames
+ */
+export function extractFilename(imagePath: string | null | undefined): string | null {
+    if (!imagePath) return null;
+
+    // Handle /api/images/filename format
+    if (imagePath.startsWith('/api/images/')) {
+        return path.basename(imagePath);
+    }
+
+    // Handle direct filename or full path
+    return path.basename(imagePath);
+}
+
+/**
+ * Extract all image paths from a post
+ */
+export function extractPostImagePaths(post: {
+    featuredImage?: string | null;
+    ogImage?: string | null;
+}): string[] {
+    const images: string[] = [];
+
+    if (post.featuredImage) {
+        const filename = extractFilename(post.featuredImage);
+        if (filename) images.push(filename);
+    }
+
+    if (post.ogImage) {
+        const filename = extractFilename(post.ogImage);
+        if (filename) images.push(filename);
+    }
+
+    return images;
+}
+
+/**
+ * Delete a single image file from the uploads directory
+ * @returns true if deleted successfully, false if file doesn't exist or error
+ */
+export async function deleteImageFile(filename: string): Promise<boolean> {
+    try {
+        const sanitizedFilename = path.basename(filename);
+        const filePath = path.join(uploadsDir, sanitizedFilename);
+
+        if (fs.existsSync(filePath)) {
+            fs.unlinkSync(filePath);
+            return true;
+        }
+        return false;
+    } catch (error) {
+        console.warn(`Failed to delete image file: ${filename}`, error);
+        return false;
+    }
+}
+
+/**
+ * Clean up all images associated with a post
+ * @returns Array of deleted filenames
+ */
+export async function cleanupPostImages(post: {
+    featuredImage?: string | null;
+    ogImage?: string | null;
+}): Promise<string[]> {
+    const imageFilenames = extractPostImagePaths(post);
+    const deletedFiles: string[] = [];
+
+    for (const filename of imageFilenames) {
+        const deleted = await deleteImageFile(filename);
+        if (deleted) {
+            deletedFiles.push(filename);
+        }
+    }
+
+    return deletedFiles;
+}
+
+/**
+ * Get all image filenames currently in the uploads directory
+ */
+export function getAllUploadedImages(): string[] {
+    try {
+        if (!fs.existsSync(uploadsDir)) {
+            return [];
+        }
+
+        const files = fs.readdirSync(uploadsDir);
+        return files.filter(file => {
+            const filePath = path.join(uploadsDir, file);
+            return fs.statSync(filePath).isFile();
+        });
+    } catch (error) {
+        console.warn('Failed to read uploads directory', error);
+        return [];
+    }
+}
+
+/**
+ * Get all image references from the database (featuredImage and ogImage fields)
+ */
+export async function getAllReferencedImages(): Promise<Set<string>> {
+    const posts = await prisma.post.findMany({
+        select: {
+            featuredImage: true,
+            ogImage: true,
+        },
+    });
+
+    const referencedImages = new Set<string>();
+
+    for (const post of posts) {
+        const filenames = extractPostImagePaths(post);
+        filenames.forEach(f => referencedImages.add(f));
+    }
+
+    return referencedImages;
+}
+
+/**
+ * Find orphaned images (images in uploads not referenced by any post)
+ */
+export async function getOrphanedImages(): Promise<string[]> {
+    const uploadedImages = getAllUploadedImages();
+    const referencedImages = await getAllReferencedImages();
+
+    return uploadedImages.filter(filename => !referencedImages.has(filename));
+}
+
+/**
+ * Delete all orphaned images
+ * @returns Object with deleted and failed arrays
+ */
+export async function cleanupOrphanedImages(): Promise<{
+    deleted: string[];
+    failed: string[];
+}> {
+    const orphanedImages = await getOrphanedImages();
+    const deleted: string[] = [];
+    const failed: string[] = [];
+
+    for (const filename of orphanedImages) {
+        const success = await deleteImageFile(filename);
+        if (success) {
+            deleted.push(filename);
+        } else {
+            failed.push(filename);
+        }
+    }
+
+    return { deleted, failed };
+}

--- a/src/test/imageCleanup.test.ts
+++ b/src/test/imageCleanup.test.ts
@@ -1,0 +1,262 @@
+import request from "supertest";
+import { setupPrismaMock } from "./utils/mockPrisma";
+import jwt from "jsonwebtoken";
+import fs from "fs";
+import path from "path";
+
+// Import prisma and app AFTER mocks are set up
+import { prisma } from "../lib/prisma";
+import app from "../index";
+
+const { prisma: prismaMock, app: appInstance } = setupPrismaMock(prisma, app);
+
+describe("Image Cleanup", () => {
+
+    let authToken: string;
+    const uploadsDir = path.join(process.cwd(), "uploads");
+
+    const mockUser = {
+        id: "user-123",
+        email: "test@example.com",
+        username: "testuser",
+        password: "hashedPassword",
+        deletedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    };
+
+    beforeEach(async () => {
+        // Mock user for authentication
+        (prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+
+        // Generate token
+        authToken = jwt.sign({ userId: mockUser.id }, process.env.JWT_SECRET!);
+
+        // Ensure uploads directory exists
+        if (!fs.existsSync(uploadsDir)) {
+            fs.mkdirSync(uploadsDir, { recursive: true });
+        }
+    });
+
+    afterEach(async () => {
+        // Clean up uploaded files
+        if (fs.existsSync(uploadsDir)) {
+            const files = fs.readdirSync(uploadsDir);
+            files.forEach((file) => {
+                const filePath = path.join(uploadsDir, file);
+                if (fs.statSync(filePath).isFile()) {
+                    fs.unlinkSync(filePath);
+                }
+            });
+        }
+    });
+
+    describe("imageCleanupService", () => {
+        it("should export all required functions from service", () => {
+            const service = require("../services/imageCleanupService");
+            expect(service.extractFilename).toBeDefined();
+            expect(service.extractPostImagePaths).toBeDefined();
+            expect(service.deleteImageFile).toBeDefined();
+            expect(service.cleanupPostImages).toBeDefined();
+            expect(service.getAllUploadedImages).toBeDefined();
+            expect(service.getAllReferencedImages).toBeDefined();
+            expect(service.getOrphanedImages).toBeDefined();
+            expect(service.cleanupOrphanedImages).toBeDefined();
+        });
+
+        it("extractFilename should extract filename from /api/images/ path", () => {
+            const { extractFilename } = require("../services/imageCleanupService");
+            expect(extractFilename("/api/images/test-123.jpg")).toBe("test-123.jpg");
+            expect(extractFilename("/api/images/my-image.png")).toBe("my-image.png");
+        });
+
+        it("extractFilename should handle null/undefined", () => {
+            const { extractFilename } = require("../services/imageCleanupService");
+            expect(extractFilename(null)).toBeNull();
+            expect(extractFilename(undefined)).toBeNull();
+        });
+
+        it("extractPostImagePaths should extract all image paths from post", () => {
+            const { extractPostImagePaths } = require("../services/imageCleanupService");
+
+            const post = {
+                featuredImage: "/api/images/featured-123.jpg",
+                ogImage: "/api/images/og-456.png",
+            };
+
+            const paths = extractPostImagePaths(post);
+            expect(paths).toContain("featured-123.jpg");
+            expect(paths).toContain("og-456.png");
+            expect(paths.length).toBe(2);
+        });
+
+        it("extractPostImagePaths should handle missing images", () => {
+            const { extractPostImagePaths } = require("../services/imageCleanupService");
+
+            const post = {
+                featuredImage: null,
+                ogImage: undefined,
+            };
+
+            const paths = extractPostImagePaths(post);
+            expect(paths.length).toBe(0);
+        });
+
+        it("deleteImageFile should delete existing file", async () => {
+            const { deleteImageFile } = require("../services/imageCleanupService");
+
+            // Create a test file
+            const testFilename = "test-delete-" + Date.now() + ".jpg";
+            const testFilePath = path.join(uploadsDir, testFilename);
+            fs.writeFileSync(testFilePath, "test content");
+
+            expect(fs.existsSync(testFilePath)).toBe(true);
+
+            const result = await deleteImageFile(testFilename);
+
+            expect(result).toBe(true);
+            expect(fs.existsSync(testFilePath)).toBe(false);
+        });
+
+        it("deleteImageFile should return false for non-existent file", async () => {
+            const { deleteImageFile } = require("../services/imageCleanupService");
+
+            const result = await deleteImageFile("non-existent-file.jpg");
+
+            expect(result).toBe(false);
+        });
+
+        it("cleanupPostImages should delete all associated images", async () => {
+            const { cleanupPostImages } = require("../services/imageCleanupService");
+
+            // Create test files
+            const featuredFilename = "featured-" + Date.now() + ".jpg";
+            const ogFilename = "og-" + Date.now() + ".png";
+
+            fs.writeFileSync(path.join(uploadsDir, featuredFilename), "featured content");
+            fs.writeFileSync(path.join(uploadsDir, ogFilename), "og content");
+
+            const post = {
+                featuredImage: `/api/images/${featuredFilename}`,
+                ogImage: `/api/images/${ogFilename}`,
+            };
+
+            const deleted = await cleanupPostImages(post);
+
+            expect(deleted).toContain(featuredFilename);
+            expect(deleted).toContain(ogFilename);
+            expect(fs.existsSync(path.join(uploadsDir, featuredFilename))).toBe(false);
+            expect(fs.existsSync(path.join(uploadsDir, ogFilename))).toBe(false);
+        });
+
+        it("getAllUploadedImages should return all files in uploads directory", () => {
+            const { getAllUploadedImages } = require("../services/imageCleanupService");
+
+            // Create test files
+            const testFiles = ["test1.jpg", "test2.png", "test3.gif"];
+            testFiles.forEach(f => {
+                fs.writeFileSync(path.join(uploadsDir, f), "content");
+            });
+
+            const uploaded = getAllUploadedImages();
+
+            testFiles.forEach(f => {
+                expect(uploaded).toContain(f);
+            });
+        });
+
+        it("getOrphanedImages should find images not referenced by any post", async () => {
+            const { getOrphanedImages } = require("../services/imageCleanupService");
+
+            // Create orphaned file
+            const orphanedFilename = "orphaned-" + Date.now() + ".jpg";
+            fs.writeFileSync(path.join(uploadsDir, orphanedFilename), "orphaned content");
+
+            // Mock prisma.post.findMany to return no posts
+            (prismaMock.post.findMany as jest.Mock).mockResolvedValue([]);
+
+            const orphaned = await getOrphanedImages();
+
+            expect(orphaned).toContain(orphanedFilename);
+        });
+
+        it("cleanupOrphanedImages should delete all orphaned images", async () => {
+            const { cleanupOrphanedImages } = require("../services/imageCleanupService");
+
+            // Create orphaned files
+            const orphanedFiles = [
+                "orphan1-" + Date.now() + ".jpg",
+                "orphan2-" + Date.now() + ".png",
+            ];
+            orphanedFiles.forEach(f => {
+                fs.writeFileSync(path.join(uploadsDir, f), "orphaned content");
+            });
+
+            // Mock prisma.post.findMany to return no posts
+            (prismaMock.post.findMany as jest.Mock).mockResolvedValue([]);
+
+            const result = await cleanupOrphanedImages();
+
+            expect(result.deleted.length).toBeGreaterThanOrEqual(2);
+            orphanedFiles.forEach(f => {
+                expect(fs.existsSync(path.join(uploadsDir, f))).toBe(false);
+            });
+        });
+    });
+
+    describe("GET /api/images/orphaned", () => {
+        it("should return list of orphaned images when authenticated", async () => {
+            // Create orphaned file
+            const orphanedFilename = "orphaned-get-" + Date.now() + ".jpg";
+            fs.writeFileSync(path.join(uploadsDir, orphanedFilename), "orphaned content");
+
+            // Mock prisma.post.findMany to return no posts
+            (prismaMock.post.findMany as jest.Mock).mockResolvedValue([]);
+
+            const response = await request(appInstance)
+                .get("/api/images/orphaned")
+                .set("Authorization", `Bearer ${authToken}`)
+                .expect(200);
+
+            expect(response.body).toHaveProperty("message", "Orphaned images retrieved successfully");
+            expect(response.body).toHaveProperty("count");
+            expect(response.body).toHaveProperty("images");
+            expect(Array.isArray(response.body.images)).toBe(true);
+        });
+
+        it("should reject request when not authenticated", async () => {
+            await request(appInstance)
+                .get("/api/images/orphaned")
+                .expect(401);
+        });
+    });
+
+    describe("DELETE /api/images/orphaned", () => {
+        it("should delete orphaned images when authenticated", async () => {
+            // Create orphaned files
+            const orphanedFilename = "orphaned-delete-" + Date.now() + ".jpg";
+            fs.writeFileSync(path.join(uploadsDir, orphanedFilename), "orphaned content");
+
+            // Mock prisma.post.findMany to return no posts
+            (prismaMock.post.findMany as jest.Mock).mockResolvedValue([]);
+
+            const response = await request(appInstance)
+                .delete("/api/images/orphaned")
+                .set("Authorization", `Bearer ${authToken}`)
+                .expect(200);
+
+            expect(response.body).toHaveProperty("message", "Orphaned images cleanup completed");
+            expect(response.body).toHaveProperty("deletedCount");
+            expect(response.body).toHaveProperty("deleted");
+
+            // Verify file was deleted
+            expect(fs.existsSync(path.join(uploadsDir, orphanedFilename))).toBe(false);
+        });
+
+        it("should reject request when not authenticated", async () => {
+            await request(appInstance)
+                .delete("/api/images/orphaned")
+                .expect(401);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

When a post with images is deleted, images remain orphaned in uploads. This PR adds automatic cleanup logic when posts are deleted and provides admin endpoints for detecting and removing orphaned images.

**User Story:**
> As an administrator, I want orphaned images to be automatically cleaned up when posts are deleted so that storage space is not wasted on unused files.

---

## Files Changed

| File | Change Type | Description |
|------|-------------|-------------|
| `src/services/imageCleanupService.ts` | NEW | Service with image cleanup utilities |
| `src/services/posts/postsCrudService.ts` | MODIFIED | `deletePost` now cleans up associated images |
| `src/controllers/imageController.ts` | MODIFIED | Added orphaned image controller functions |
| `src/routes/images.ts` | MODIFIED | Added orphaned image routes |
| `src/test/imageCleanup.test.ts` | NEW | Comprehensive test suite |

---

## API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/api/images/orphaned` | List orphaned images (requires auth) |
| `DELETE` | `/api/images/orphaned` | Delete all orphaned images (requires auth) |

---

## Exported Functions

**From `imageCleanupService.ts`:**
- `extractFilename()` - Extract filename from image path
- `extractPostImagePaths()` - Get all image filenames from post
- `deleteImageFile()` - Delete single image file
- `cleanupPostImages()` - Clean up all images for a post
- `getAllUploadedImages()` - List all files in uploads directory
- `getAllReferencedImages()` - Get all image references from database
- `getOrphanedImages()` - Find orphaned images
- `cleanupOrphanedImages()` - Delete all orphaned images

---

## Tests

| Test | Status |
|------|--------|
| `should export all required functions from service` | ✅ |
| `extractFilename should extract filename from /api/images/ path` | ✅ |
| `extractFilename should handle null/undefined` | ✅ |
| `extractPostImagePaths should extract all image paths from post` | ✅ |
| `extractPostImagePaths should handle missing images` | ✅ |
| `deleteImageFile should delete existing file` | ✅ |
| `deleteImageFile should return false for non-existent file` | ✅ |
| `cleanupPostImages should delete all associated images` | ✅ |
| `getAllUploadedImages should return all files in uploads directory` | ✅ |
| `getOrphanedImages should find images not referenced by any post` | ✅ |
| `cleanupOrphanedImages should delete all orphaned images` | ✅ |
| `GET /api/images/orphaned should return list when authenticated` | ✅ |
| `GET /api/images/orphaned should reject when not authenticated` | ✅ |
| `DELETE /api/images/orphaned should delete when authenticated` | ✅ |
| `DELETE /api/images/orphaned should reject when not authenticated` | ✅ |

## API Design

**Endpoints:**
| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/api/images/orphaned` | List orphaned images |
| `DELETE` | `/api/images/orphaned` | Delete all orphaned images |

**Response Format:**
```typescript
// GET /api/images/orphaned (200 OK)
{
    "message": "Orphaned images retrieved successfully",
    "count": 5,
    "images": ["orphan1.jpg", "orphan2.png"]
}

// DELETE /api/images/orphaned (200 OK)
{
    "message": "Orphaned images cleanup completed",
    "deletedCount": 4,
    "failedCount": 1,
    "deleted": ["orphan1.jpg"],
    "failed": ["locked.jpg"]
}
```

## Related Issue:
close #195

## Screenshot:

### Before:
<img width="923" height="533" alt="image-cleanup-on-post-delete-before" src="https://github.com/user-attachments/assets/9d5128f9-a165-4c31-9c1d-19f378b49a14" />

### After:
<img width="957" height="535" alt="image-cleanup-on-post-delete-after" src="https://github.com/user-attachments/assets/ae9525fe-2166-4c27-b3eb-4c82cb6c8e60" />

## Eval Tool Link: 
https://eval.turing.com/conversations/217269/view