### PR TITLE
implement user roles at database level

### DIFF
--- a/prisma/migrations/20251211051301_add_user_role/migration.sql
+++ b/prisma/migrations/20251211051301_add_user_role/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('ADMIN', 'AUTHOR');
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "role" "Role" NOT NULL DEFAULT 'AUTHOR';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,7 @@ model User {
   email               String          @unique
   username            String          @unique
   password            String
+  role                Role            @default(AUTHOR)
   createdAt           DateTime        @default(now())
   updatedAt           DateTime        @updatedAt
   about               String?
@@ -222,6 +223,11 @@ enum ReportStatus {
   PENDING
   REVIEWED
   REJECTED
+}
+
+enum Role {
+  ADMIN
+  AUTHOR
 }
 
 model UserCommenterStats {

--- a/src/test/commentReporting.test.ts
+++ b/src/test/commentReporting.test.ts
@@ -454,6 +454,7 @@ describe('Comment Reporting and Moderation API', () => {
         id: adminId,
         email: adminEmail,
         username: 'admin',
+        role: 'ADMIN' as const,
         deletedAt: null,
       };
 
@@ -476,9 +477,6 @@ describe('Comment Reporting and Moderation API', () => {
         },
       ];
 
-      const originalAdminEmails = process.env.ADMIN_EMAILS;
-      process.env.ADMIN_EMAILS = adminEmail;
-
       (prismaMock.user.findUnique as jest.Mock).mockImplementation(({ where }) => {
         if (where.id === adminId) {
           return Promise.resolve(mockAdmin);
@@ -500,12 +498,6 @@ describe('Comment Reporting and Moderation API', () => {
         status: ReportStatus.PENDING,
       });
 
-      // Restore original environment variable
-      if (originalAdminEmails !== undefined) {
-        process.env.ADMIN_EMAILS = originalAdminEmails;
-      } else {
-        delete process.env.ADMIN_EMAILS;
-      }
     });
 
     it('should reject access by non-admin users', async () => {

--- a/src/test/images.test.ts
+++ b/src/test/images.test.ts
@@ -37,6 +37,7 @@ describe("Image Routes", () => {
 		email: "test@example.com",
 		username: "testuser",
 		password: "hashedPassword",
+		role: "AUTHOR" as const,
 		deletedAt: null,
 		createdAt: new Date(),
 		updatedAt: new Date(),

--- a/src/test/tags.test.ts
+++ b/src/test/tags.test.ts
@@ -290,26 +290,22 @@ describe('Tags API', () => {
       id: 'admin-1',
       email: 'admin@example.com',
       username: 'admin',
+      role: 'ADMIN' as const,
       deletedAt: null,
     };
     const mockAuthor = {
       id: 'author-1',
       email: 'author@example.com',
       username: 'author',
+      role: 'AUTHOR' as const,
       deletedAt: null,
     };
 
     beforeEach(() => {
       // Clear cache before each test
       invalidateCache.invalidateAll();
-      // Set admin email for admin tests
-      process.env.ADMIN_EMAILS = 'admin@example.com';
       adminToken = generateToken(mockAdmin.id);
       authorToken = generateToken(mockAuthor.id);
-    });
-
-    afterEach(() => {
-      delete process.env.ADMIN_EMAILS;
     });
 
     describe('POST /api/tags - Create Tag', () => {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -23,22 +23,16 @@ export interface AuthRequest extends Request {
 }
 
 /**
- * Determines user role based on user ID and email
- * Checks against admin lists from environment variables, defaults to AUTHOR
- * Reads environment variables at call time to allow test configuration
+ * Determines user role from the database
+ * Returns the role stored in the user's record, defaults to AUTHOR if not found
  */
-export const getUserRole = async (userId: string, email: string): Promise<Role> => {
-  // Read admin lists from environment at call time (not module load time)
-  const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim()).filter(Boolean) || [];
-  const adminUserIds = process.env.ADMIN_USER_IDS?.split(',').map(id => id.trim()).filter(Boolean) || [];
+export const getUserRole = async (userId: string): Promise<Role> => {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { role: true },
+  });
   
-  // Check if user is in admin list
-  if (adminEmails.includes(email) || adminUserIds.includes(userId)) {
-    return 'ADMIN';
-  }
-  
-  // Default to AUTHOR
-  return 'AUTHOR';
+  return user?.role ?? 'AUTHOR';
 };
 
 export const generateToken = (userId: string): string => {
@@ -144,7 +138,7 @@ export const authenticateToken = async (
 
     const user = await prisma.user.findUnique({
       where: { id: decoded.userId },
-      select: { id: true, email: true, username: true, deletedAt: true },
+      select: { id: true, email: true, username: true, role: true, deletedAt: true },
     });
 
     if (!user) {
@@ -157,10 +151,7 @@ export const authenticateToken = async (
       return;
     }
 
-    // Determine user role
-    const role = await getUserRole(user.id, user.email);
-
-    req.user = { id: user.id, email: user.email, username: user.username, role };
+    req.user = { id: user.id, email: user.email, username: user.username, role: user.role };
     next();
   } catch (error) {
     res.status(403).json({ error: 'Invalid or expired token' });


### PR DESCRIPTION
# Summary

Implements user roles at the database level, replacing environment variable-based role determination. This improves role management, enables role querying, and allows runtime role changes without server restarts.

fixes #169

---

## Changes

### Added

| File | Description |
|------|-------------|
| `prisma/migrations/20251211051301_add_user_role/migration.sql` | Migration to add Role enum and role column |

### Updated

| File | Description |
|------|-------------|
| `prisma/schema.prisma` | Added `Role` enum (ADMIN, AUTHOR) and `role` field to User model |
| `src/utils/auth.ts` | `getUserRole()` now reads from database instead of env vars |
| `src/controllers/authController.ts` | Signup/login return role from database |
| `src/test/authorization.test.ts` | Updated mock users to include role field |
| `src/test/images.test.ts` | Updated mock user with role |
| `src/test/tags.test.ts` | Updated mock admin/author with roles |
| `src/test/commentReporting.test.ts` | Updated mock admin with role |
| `src/test/reports.test.ts` | Refactored to use separate admin/user mocks with roles |

---

## Features

| Feature | Description |
|---------|-------------|
| Database roles | Role stored as column in users table |
| Default role | New users automatically get `AUTHOR` role |
| Runtime changes | Change roles without server restart |
| Queryable | Can query all admins: `SELECT * FROM users WHERE role = 'ADMIN'` |
| Role hierarchy | ADMIN inherits AUTHOR permissions |

---

## API Response Examples

### Signup:
```json
{
  "message": "User created successfully",
  "user": {
    "id": "cmj11zrtu000210ptxxiy4w3u",
    "email": "newuser@example.com",
    "username": "newuser",
    "role": "AUTHOR"
  }
}
```

### Login:
```json
{
  "message": "Login successful",
  "user": {
    "id": "cmj11zrtu000210ptxxiy4w3u",
    "email": "admin@example.com",
    "username": "admin",
    "role": "ADMIN"
  }
}
```

---

## Database Changes

```sql
-- CreateEnum
CREATE TYPE "Role" AS ENUM ('ADMIN', 'AUTHOR');

-- AlterTable
ALTER TABLE "users" ADD COLUMN "role" "Role" NOT NULL DEFAULT 'AUTHOR';
```

---

## Testing

- [x] Unit tests updated for new role structure
- [x] Manual verification: New user gets AUTHOR role
- [x] Manual verification: Login returns role from database
- [x] Manual verification: Admin routes work with DB role
- [x] All 126 tests passing

---

## Checklist

- [x] Code follows existing patterns
- [x] Tests updated and passing
- [x] Database migration added
- [x] No new dependencies required
- [x] Backward compatible (existing users default to AUTHOR)

---

## Migration Notes

After deploying, promote admin users manually:

```sql
UPDATE users SET role = 'ADMIN' WHERE email = 'admin@example.com';
```

Or use Prisma Studio:
```bash
npx prisma studio
```